### PR TITLE
? and 'help' headless commands are more consistent

### DIFF
--- a/source/headless.py
+++ b/source/headless.py
@@ -1334,7 +1334,7 @@ class CommandInput(urwid.Edit):
         if key == '?':
             help_content = commands['help'].show_command_help(self.get_edit_text().split(' '))
             if help_content:
-                command_content.set_text([('info', response_header), *help_content])
+                command_content.set_text([('success', response_header), *help_content])
             return
 
 


### PR DESCRIPTION
The PR dump is as follows:

- Commit [39f6a11d490226c072cd59b07170235a4f7cf556](https://github.com/stag-enterprises/PATCHED-auto-mcs/commit/39f6a11d490226c072cd59b07170235a4f7cf556) (view [patch](https://github.com/stag-enterprises/PATCHED-auto-mcs/commit/39f6a11d490226c072cd59b07170235a4f7cf556.patch) or [diff](https://github.com/stag-enterprises/PATCHED-auto-mcs/commit/39f6a11d490226c072cd59b07170235a4f7cf556.diff))
	- including a 620-character commit message, starting with
		- ? and 'help' headless commands are more consistent
		- In the headless TUI, there are two ways to access...
	- changing 1 file, with adding 1 line and removing 1 line
		- source/headless.py: 1+ 1-
	- made at Wed, 22 Jan 2025 22:25:45 -0500
	- signed off and verified

- In **summary**, this PR
	- has 1 commit, totaling 620 characters of commit messages
	- changes 1 file, adding 1 line and removing 1 line in total
	- is generated at Wed, 22 Jan 2025 22:46:10 -0500
	- has all commits signed off and verified
	- is from branch [patch/headless-help-consistency](https://github.com/stag-enterprises/PATCHED-auto-mcs/tree/patch/headless-help-consistency) (view [diff](https://github.com/stag-enterprises/PATCHED-auto-mcs/compare/patch/headless-help-consistency))
	- is on repository [stag-enterprises/PATCHED-auto-mcs](https://github.com/stag-enterprises/PATCHED-auto-mcs)

*This PR description was auto-generated because the author is a lazy bastard and can't be arsed to write a description. Please go complain in their DMs and send them helpful encouragement.*