### PR TITLE
Update Python to 3.12

### DIFF
--- a/.github/workflows/compiler.yml
+++ b/.github/workflows/compiler.yml
@@ -74,7 +74,7 @@ jobs:
           systeminfo
           $python_path = "$env:LOCALAPPDATA\Programs\Python\Python312"
           md $python_path
-          Move-Item -Force C:\hostedtoolcache\windows\Python\3.12.8\x64\* $python_path
+          Move-Item -Force C:\hostedtoolcache\windows\Python\3.12.*\x64\* $python_path
 
           powershell -noprofile -executionpolicy bypass `
             -file .\build-tools\build-windows.ps1 `

--- a/.github/workflows/compiler.yml
+++ b/.github/workflows/compiler.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           
       - name: Compile auto-mcs
         shell: pwsh
@@ -72,9 +72,9 @@ jobs:
 
           # Build auto-mcs
           systeminfo
-          $python_path = "$env:LOCALAPPDATA\Programs\Python\Python39"
+          $python_path = "$env:LOCALAPPDATA\Programs\Python\Python312"
           md $python_path
-          Move-Item -Force C:\hostedtoolcache\windows\Python\3.9.13\x64\* $python_path
+          Move-Item -Force C:\hostedtoolcache\windows\Python\3.12.8\x64\* $python_path
 
           powershell -noprofile -executionpolicy bypass `
             -file .\build-tools\build-windows.ps1 `
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          brew install python@3.9 python-tk@3.9 create-dmg
+          brew install python@3.12 python-tk@3.12 create-dmg
       
       - name: Compile auto-mcs
         run: |
@@ -214,7 +214,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9.18'
+          python-version: '3.12'
     
       - name: Compile auto-mcs
         run: |
@@ -274,7 +274,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9.18'
+          python-version: '3.12'
 
       - name: Compile auto-mcs
         run: |
@@ -332,7 +332,7 @@ jobs:
         - name: Setup Alpine Linux
           uses: jirutka/setup-alpine@v1
           with:
-            branch: v3.15
+            branch: v3.21
 
         - name: Install Dependencies
           run: |
@@ -390,7 +390,7 @@ jobs:
         uses: jirutka/setup-alpine@v1
         with:
           arch: aarch64
-          branch: v3.15
+          branch: v3.21
           apk-tools-url: "https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878"
 
       - name: Install Dependencies

--- a/.github/workflows/compiler.yml
+++ b/.github/workflows/compiler.yml
@@ -129,7 +129,7 @@ jobs:
           mkdir -p /Users/runner/Library/Fonts
           chmod +x build-macos.sh
 
-          sudo -E ./build-macos.sh \
+          ./build-macos.sh \
             --branch "${{ github.ref_name }}" \
             --build  "${{ github.run_number }}" \
             --commit "${{ github.sha }}" \
@@ -231,7 +231,7 @@ jobs:
           cd build-tools
           chmod +x build-linux.sh
 
-          sudo -E ./build-linux.sh \
+          ./build-linux.sh \
             --branch "${{ github.ref_name }}" \
             --build  "${{ github.run_number }}" \
             --commit "${{ github.sha }}" \
@@ -292,7 +292,7 @@ jobs:
           cd build-tools
           chmod +x build-linux.sh
 
-          sudo -E ./build-linux.sh \
+          ./build-linux.sh \
             --branch "${{ github.ref_name }}" \
             --build  "${{ github.run_number }}" \
             --commit "${{ github.sha }}" \

--- a/build-tools/auto-mcs.docker.spec
+++ b/build-tools/auto-mcs.docker.spec
@@ -17,6 +17,7 @@ from compile_helper import *
 block_cipher = None
 hiddenimports = ['dataclasses', 'nbt.world', 'pkg_resources.extern']
 hiddenimports.extend(collect_submodules('uvicorn'))
+hiddenimports.extend(collect_submodules('numpy'))
 hiddenimports.extend(collect_internal_modules())
 
 sys.modules['FixTk'] = None

--- a/build-tools/auto-mcs.linux.spec
+++ b/build-tools/auto-mcs.linux.spec
@@ -17,6 +17,7 @@ from compile_helper import *
 block_cipher = None
 hiddenimports = ['plyer.platforms.linux.filechooser', 'PIL._tkinter_finder', 'dataclasses', 'nbt.world', 'pkg_resources.extern']
 hiddenimports.extend(collect_submodules('uvicorn'))
+hiddenimports.extend(collect_submodules('numpy'))
 hiddenimports.extend(collect_internal_modules())
 
 

--- a/build-tools/auto-mcs.macos.spec
+++ b/build-tools/auto-mcs.macos.spec
@@ -17,6 +17,7 @@ from compile_helper import *
 block_cipher = None
 hiddenimports = ['plyer.platforms.macosx.filechooser', 'PIL._tkinter_finder', 'dataclasses', 'nbt.world', 'pkg_resources.extern']
 hiddenimports.extend(collect_submodules('uvicorn'))
+hiddenimports.extend(collect_submodules('numpy'))
 hiddenimports.extend(collect_internal_modules())
 
 

--- a/build-tools/auto-mcs.windows.spec
+++ b/build-tools/auto-mcs.windows.spec
@@ -17,6 +17,7 @@ from compile_helper import *
 block_cipher = None
 hiddenimports = ['plyer.platforms.win.filechooser', 'PIL._tkinter_finder', 'dataclasses', 'nbt.world', 'pkg_resources.extern']
 hiddenimports.extend(collect_submodules('uvicorn'))
+hiddenimports.extend(collect_submodules('numpy'))
 hiddenimports.extend(collect_internal_modules())
 
 

--- a/build-tools/build-docker.sh
+++ b/build-tools/build-docker.sh
@@ -160,7 +160,7 @@ export KIVY_AUDIO=ffpyplayer
 cd $current
 cp $spec_file ../source
 cd ../source
-pyinstaller "$spec_file" --clean
+pyinstaller "$spec_file" --clean --log-level INFO
 cd $current
 rm -rf ../source/$spec_file
 rm -rf ./dist

--- a/build-tools/build-docker.sh
+++ b/build-tools/build-docker.sh
@@ -65,8 +65,8 @@ fi
 
 
 
-# Use a fixed Python 3.9 path for Alpine
-python="/usr/bin/python3.9"
+# Use a fixed Python 3.12 path for Alpine
+python="/usr/bin/python3.12"
 venv_path="./venv"
 spec_file="auto-mcs.docker.spec"
 
@@ -85,7 +85,7 @@ error ()
 
 
 
-# First, check if a valid version of Python 3.9 is installed
+# First, check if a valid version of Python 3.12 is installed
 version=$( $python --version 2>/dev/null )
 errorlevel=$?
 if [ $errorlevel -ne 0 ]; then
@@ -94,7 +94,7 @@ if [ $errorlevel -ne 0 ]; then
     apkver=$( apk --version 2>/dev/null )
     errorlevel=$?
     if [ $errorlevel -ne 0 ]; then
-        error "This script requires Alpine (apk) or a preinstalled Python 3.9"
+        error "This script requires Alpine (apk) or a preinstalled Python 3.12"
     fi
 
     echo "Obtaining packages to install Python and build tools"
@@ -102,7 +102,7 @@ if [ $errorlevel -ne 0 ]; then
     # (X server bits for PyInstaller, toolchain for building wheels)
     apk add --no-cache \
         bash coreutils \
-        python3=3.9.13-r* python3-dev=3.9.13-r* py3-pip=22.* \
+        python3=3.12.8-r* python3-dev=3.12.8-r* py3-pip=22.* \
         gcc g++ make musl-dev linux-headers \
         zlib-dev libffi-dev \
         pangomm-dev pkgconfig \
@@ -114,14 +114,14 @@ if [ $errorlevel -ne 0 ]; then
         error "Something went wrong installing packages, please try again"
     fi
 
-    # After install, prefer python3.9 explicitly
-    python="/usr/bin/python3.9"
+    # After install, prefer python3.12 explicitly
+    python="/usr/bin/python3.12"
     version=$( $python --version 2>/dev/null ) || true
 fi
 
 
 
-# If Python 3.9 is installed, check for a virtual environment
+# If Python 3.12 is installed, check for a virtual environment
 cd $current
 echo Detected $version
 

--- a/build-tools/build-linux.sh
+++ b/build-tools/build-linux.sh
@@ -67,19 +67,19 @@ fi
 
 # Global variables
 shopt -s expand_aliases
-python_path="/opt/python/3.9.18"
+python_path="/opt/python/3.12.8"
 
-# Locate python3.9 if it exists, otherwise set the default dir for building from source
-if [[ -n "${pythonLocation:-}" && -x "$pythonLocation/bin/python3.9" ]]; then
-  python="$pythonLocation/bin/python3.9"
-elif command -v python3.9 >/dev/null 2>&1; then
-  python="$(command -v python3.9)"
-elif [[ -x /usr/bin/python3.9 ]]; then
-  python="/usr/bin/python3.9"
-elif ls /opt/hostedtoolcache/Python/3.9.*/x64/bin/python3.9 >/dev/null 2>&1; then
-  python="$(ls -d /opt/hostedtoolcache/Python/3.9.*/x64/bin/python3.9 | head -n1)"
+# Locate python3.12 if it exists, otherwise set the default dir for building from source
+if [[ -n "${pythonLocation:-}" && -x "$pythonLocation/bin/python3.12" ]]; then
+  python="$pythonLocation/bin/python3.12"
+elif command -v python3.12 >/dev/null 2>&1; then
+  python="$(command -v python3.12)"
+elif [[ -x /usr/bin/python3.12 ]]; then
+  python="/usr/bin/python3.12"
+elif ls /opt/hostedtoolcache/Python/3.12.*/x64/bin/python3.12 >/dev/null 2>&1; then
+  python="$(ls -d /opt/hostedtoolcache/Python/3.12.*/x64/bin/python3.12 | head -n1)"
 else
-  python="/opt/python/3.9.18/bin/python3.9"
+  python="/opt/python/3.12.8/bin/python3.12"
 fi
 
 library_path=$( ldconfig -v 2>/dev/null | cut -d'/' -f1-3 | head -n1 )
@@ -128,7 +128,7 @@ if [ ${DISPLAY:-"unset"} == "unset" ]; then
 fi
 
 
-# First, check if a valid version of Python 3.9 is installed
+# First, check if a valid version of Python 3.12 is installed
 version=$( $python --version )
 errorlevel=$?
 if [ $errorlevel -ne 0 ]; then
@@ -139,7 +139,7 @@ if [ $errorlevel -ne 0 ]; then
 	elif [ -x "$(command -v dnf)" ];     then dnf -y groupinstall "Development Tools" && sudo dnf -y install wget gcc bzip2-devel libffi-devel xz-devel freetype-devel portaudio-devel
 	elif [ -x "$(command -v yum)" ];     then yum -y groupinstall "Development Tools" && sudo dnf -y install wget gcc bzip2-devel libffi-devel xz-devel freetype-devel portaudio-devel
 	elif [ -x "$(command -v pacman)" ];  then pacman -S --noconfirm base-devel wget openssl-1.1 tk freetype2 portaudio
-	else echo "[WARNING] Package manager not found: You must manually install the Python 3.9 source dependencies">&2; fi
+	else echo "[WARNING] Package manager not found: You must manually install the Python 3.12 source dependencies">&2; fi
 
 
 
@@ -180,12 +180,12 @@ if [ $errorlevel -ne 0 ]; then
 
 
 	# Finally, download and compile Python from source
-	echo Installing Python 3.9
+	echo Installing Python 3.12
 
 	cd /tmp/
-	wget https://www.python.org/ftp/python/3.9.18/Python-3.9.18.tgz
-	tar xzf Python-3.9.18.tgz
-	cd Python-3.9.18
+	wget https://www.python.org/ftp/python/3.12.8/Python-3.12.8.tgz
+	tar xzf Python-3.12.8.tgz
+	cd Python-3.12.8
 
 	mkdir -p $python_path/lib
 
@@ -202,7 +202,7 @@ if [ $errorlevel -ne 0 ]; then
 
 	make -j "$(nproc)"
 	make altinstall
-	rm /tmp/Python-3.9.18.tgz
+	rm /tmp/Python-3.12.8.tgz
 
 	errorlevel=$?
 	if [ $errorlevel -ne 0 ]; then
@@ -213,7 +213,7 @@ fi
 
 
 
-# If Python 3.9 is installed and a DE is present, check for a virtual environment
+# If Python 3.12 is installed and a DE is present, check for a virtual environment
 cd $current
 echo Detected $version
 
@@ -237,17 +237,17 @@ runas pip install --upgrade -r ./reqs-linux.txt
 
 # Patch and install Kivy hook for Pyinstaller
 patch() {
-	kivy_path=$1"/python3.9/site-packages/kivy/tools/packaging/pyinstaller_hooks"
+	kivy_path=$1"/python3.12/site-packages/kivy/tools/packaging/pyinstaller_hooks"
 	sed -i 's/from PyInstaller.compat import modname_tkinter/#/' $kivy_path/__init__.py
 	sed -i 's/excludedimports = \[modname_tkinter, /excludedimports = [/' $kivy_path/__init__.py
-	runas "$venv_path/bin/python3.9" -m kivy.tools.packaging.pyinstaller_hooks hook "$kivy_path/kivy-hook.py"
+	runas "$venv_path/bin/python3.12" -m kivy.tools.packaging.pyinstaller_hooks hook "$kivy_path/kivy-hook.py"
 }
 patch $venv_path"/lib"
 patch $venv_path"/lib64"
 
 
 # Patch plyer (pull #822)
-FILECHOOSER="$venv_path/lib/python3.9/site-packages/plyer/platforms/linux/filechooser.py"
+FILECHOOSER="$venv_path/lib/python3.12/site-packages/plyer/platforms/linux/filechooser.py"
 sed -i 's/--confirm-overwrite//g' "$FILECHOOSER"
 sed -i '/self\.title/d' "$FILECHOOSER"
 sed -i '/self\.icon/d' "$FILECHOOSER"

--- a/build-tools/build-linux.sh
+++ b/build-tools/build-linux.sh
@@ -115,12 +115,6 @@ runas() {
 }
 
 
-# Force script to be run as root
-if ! whoami | grep -q "root"; then
-	error "This script requires root privileges to run"
-fi
-
-
 
 # Check for a set DISPLAY variable
 if [ ${DISPLAY:-"unset"} == "unset" ]; then
@@ -132,6 +126,13 @@ fi
 version=$( $python --version )
 errorlevel=$?
 if [ $errorlevel -ne 0 ]; then
+
+	# Force script to be run as root if it requires an installation
+	if ! whoami | grep -q "root"; then
+		error "This script requires root privileges to install Python"
+	fi
+
+
 	echo Obtaining packages to build Python from source
 
 	# Determine system package manager and install appropriate packages

--- a/build-tools/build-linux.sh
+++ b/build-tools/build-linux.sh
@@ -102,11 +102,11 @@ error () {
 }
 
 runas() {
-		# Run command as the current user in CI
-    if [[ "${CI:-}" == "true" ]]; then
+	# Run command as the current user in CI, or when not running as root
+    if [[ "${CI:-}" == "true" ]] || ! whoami | grep -q "root"; then
         "$@"
     
-		# Run command as the login user outside CI
+	# Run command as the login user outside CI
     else
         local cmd
         cmd=$(printf '%q ' "$@")

--- a/build-tools/build-linux.sh
+++ b/build-tools/build-linux.sh
@@ -273,7 +273,7 @@ cd $current
 cp $spec_file ../source
 cd ../source
 chmod +x $current/upx/linux/*
-runas pyinstaller "$spec_file" --upx-dir "$current/upx/linux" --clean
+runas pyinstaller "$spec_file" --upx-dir "$current/upx/linux" --clean --log-level INFO
 cd $current
 rm -rf ../source/$spec_file
 mv -f ../source/dist .

--- a/build-tools/build-macos.sh
+++ b/build-tools/build-macos.sh
@@ -73,7 +73,7 @@ if [ "$(uname -m)" = "x86_64" ]; then
 	python="/usr/local/bin/python3.12"
 	brew="/usr/local/bin/brew"
 else
-	python="/opt/homebrew/opt/python@3.12/libexec/bin/python3"
+	python="/opt/homebrew/opt/python@3.12/libexec/bin/python"
 	brew="/opt/homebrew/bin/brew"
 fi
 venv_path="./venv"

--- a/build-tools/build-macos.sh
+++ b/build-tools/build-macos.sh
@@ -70,10 +70,10 @@ shopt -s expand_aliases
 
 # Use different paths for different architectures
 if [ "$(uname -m)" = "x86_64" ]; then
-	python="/usr/local/bin/python3.9"
+	python="/usr/local/bin/python3.12"
 	brew="/usr/local/bin/brew"
 else
-	python="/opt/homebrew/opt/python@3.9/libexec/bin/python3"
+	python="/opt/homebrew/opt/python@3.12/libexec/bin/python3"
 	brew="/opt/homebrew/bin/brew"
 fi
 venv_path="./venv"
@@ -96,7 +96,7 @@ error ()
 
 
 
-# First, check if a valid version of Python 3.9 is installed
+# First, check if a valid version of Python 3.12 is installed
 version=$( $python --version )
 errorlevel=$?
 if [ $errorlevel -ne 0 ]; then
@@ -121,7 +121,7 @@ if [ $errorlevel -ne 0 ]; then
 	echo Obtaining packages to install Python
 
 	# Install appropriate packages
-	eval $brew" install python@3.9 python-tk@3.9"
+	eval $brew" install python@3.12 python-tk@3.12"
 
 	errorlevel=$?
 	if [ $errorlevel -ne 0 ]; then
@@ -132,7 +132,7 @@ fi
 
 
 
-# If Python 3.9 is installed, check for a virtual environment
+# If Python 3.12 is installed, check for a virtual environment
 cd $current
 echo Detected $version
 
@@ -155,7 +155,7 @@ pip install --upgrade pip setuptools wheel
 pip install --upgrade -r ./reqs-macos.txt
 
 # Remove Kivy icons to prevent dock flickering
-rm -rf $venv_path/lib/python3.9/site-packages/kivy/data/logo/*
+rm -rf $venv_path/lib/python3.12/site-packages/kivy/data/logo/*
 
 
 # Rebuild locales.json

--- a/build-tools/build-macos.sh
+++ b/build-tools/build-macos.sh
@@ -68,14 +68,8 @@ fi
 # Global variables
 shopt -s expand_aliases
 
-# Use different paths for different architectures
-if [ "$(uname -m)" = "x86_64" ]; then
-	python="/usr/local/bin/python3.12"
-	brew="/usr/local/bin/brew"
-else
-	python="/opt/homebrew/opt/python@3.12/libexec/bin/python"
-	brew="/opt/homebrew/bin/brew"
-fi
+python="/usr/local/bin/python3.12"
+brew="/opt/homebrew/bin/brew"
 venv_path="./venv"
 spec_file="auto-mcs.macos.spec"
 
@@ -140,6 +134,7 @@ eval $python" -m pip install --upgrade pip setuptools wheel"
 
 if ! [ -d $venv_path ]; then
 	echo "A virtual environment was not detected"
+    echo $python" -m venv "$venv_path
 	eval $python" -m venv "$venv_path
 
 else

--- a/build-tools/build-macos.sh
+++ b/build-tools/build-macos.sh
@@ -165,7 +165,7 @@ cp $spec_file ../source
 cd ../source
 rm -rf build/
 rm -rf dist/
-pyinstaller "$spec_file" --clean
+pyinstaller "$spec_file" --clean --log-level INFO
 cd $current
 rm -rf ../source/$spec_file
 rm -rf ../source/dist/auto-mcs

--- a/build-tools/build-windows.ps1
+++ b/build-tools/build-windows.ps1
@@ -158,7 +158,7 @@ echo "Compiling auto-mcs"
 cd $current
 Copy-Item -Force $spec_file ..\source
 cd ..\source
-pyinstaller $spec_file --upx-dir $current\upx\windows --clean 2>&1
+pyinstaller $spec_file --upx-dir $current\upx\windows --clean --log-level INFO 2>&1
 cd $current
 Remove-Item -Force ..\source\$spec_file
 Remove-Item -Force .\dist -ErrorAction SilentlyContinue -Recurse

--- a/build-tools/build-windows.ps1
+++ b/build-tools/build-windows.ps1
@@ -64,7 +64,7 @@ if ($env:CI -eq $true) {
 
 
 # Global variables
-$python     = "$env:LOCALAPPDATA\Programs\Python\Python39\python.exe"
+$python     = "$env:LOCALAPPDATA\Programs\Python\Python312\python.exe"
 $venv_path  = ".\venv"
 $start_venv = "CALL $venv_path\Scripts\activate.bat"
 $spec_file  = "auto-mcs.windows.spec"
@@ -90,7 +90,7 @@ if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
 }
 
 
-# First, check if a valid version of Python 3.9 is installed
+# First, check if a valid version of Python 3.12 is installed
 try { $version = Invoke-Command { cmd /c "`"$python`" --version 2^> nul" } -ErrorAction Stop | Tee-Object -Variable result } catch { $version = $null }
 if (-not $version) {
     
@@ -106,10 +106,11 @@ if (-not $version) {
     Start-Process -FilePath $dest_bt -ArgumentList $arguments -Wait
 
 
-    # Download and install Python 3.9
-    echo "Downloading and installing Python 3.9"
-    $python_url = "https://www.python.org/ftp/python/3.9.13/python-3.9.13-amd64.exe"
-    $dest_py = "$env:TEMP\python_installer-3.9.13.exe"
+    # Download and install Python 3.12
+    $python_down_ver = "3.12.8"
+    echo "Downloading and installing Python $python_down_ver"
+    $python_url = "https://www.python.org/ftp/python/$python_down_ver/python-$python_down_ver-amd64.exe"
+    $dest_py = "$env:TEMP\python_installer-$python_down_ver.exe"
     echo "Downloading Python to `"$dest_py`""
     Invoke-WebRequest -Uri $python_url -OutFile $dest_py
 
@@ -121,7 +122,7 @@ if (-not $version) {
     }
 }
 
-# If Python 3.9 is installed and a DE is present, check for a virtual environment
+# If Python 3.12 is installed, check for a virtual environment
 cd $current
 echo "Detected $version"
 

--- a/build-tools/build-windows.ps1
+++ b/build-tools/build-windows.ps1
@@ -81,18 +81,18 @@ function error {
     Write-host -f Red $message
     exit 1
 }
- 
 
-
-# Force script to be run as admin
-if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-    error "This script requires administrator privileges to run"
-}
 
 
 # First, check if a valid version of Python 3.12 is installed
 try { $version = Invoke-Command { cmd /c "`"$python`" --version 2^> nul" } -ErrorAction Stop | Tee-Object -Variable result } catch { $version = $null }
 if (-not $version) {
+
+    # Force script to be run as admin if it requires an installation
+    if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        error "This script requires administrator privileges to install Python"
+    }
+
     
     # Download and install C++ Build Tools
     echo "Downloading and installing C++ Build Tools"
@@ -142,7 +142,7 @@ cmd /c "$start_venv && pip install --upgrade -r ./reqs-windows.txt"
 
 # Patch and install Kivy hook for Pyinstaller
 .\venv\Scripts\Activate.ps1
-$kivy_path= "$venv_path\Lib\site-packages\kivy\tools\packaging\pyinstaller_hooks"
+$kivy_path = "$venv_path\Lib\site-packages\kivy\tools\packaging\pyinstaller_hooks"
 ((Get-Content -Path "$kivy_path/__init__.py" ) -replace "from PyInstaller.compat import modname_tkinter","#") | Set-Content -Path "$kivy_path/__init__.py"
 ((Get-Content -Path "$kivy_path/__init__.py" ) -replace "excludedimports = \[modname_tkinter, ","excludedimports = [") | Set-Content -Path "$kivy_path/__init__.py"
 ((Get-Content -Path "$kivy_path/__init__.py" ) -replace "from os import environ","from os import environ`nfrom kivy_deps import angle`nenviron['KIVY_GL_BACKEND'] = 'angle_sdl2'") | Set-Content -Path "$kivy_path/__init__.py"

--- a/build-tools/reqs-docker.txt
+++ b/build-tools/reqs-docker.txt
@@ -15,7 +15,7 @@ NBT==1.5.1
 nbtlib==2.0.4
 Pillow==10.3.0
 psutil>=6.0.0
-pyinstaller>=5.10
+pyinstaller==6.10
 pyinstaller-hooks-contrib>=2024.7
 pyparsing==3.0.9
 requests==2.32.4

--- a/build-tools/reqs-linux.txt
+++ b/build-tools/reqs-linux.txt
@@ -10,7 +10,7 @@ dnspython==2.6.1
 docutils==0.19
 idna==3.7
 ipaddress==1.0.23
-Kivy==2.1.0
+Kivy>=2.1.0
 Kivy-Garden>=0.1.5
 munch==3.0.0
 NBT==1.5.1
@@ -19,8 +19,8 @@ Pillow==10.3.0
 plyer>=2.1.0
 psutil>=6.0.0
 Pygments==2.16.1
-pyinstaller==5.10
-pyinstaller-hooks-contrib==2024.10
+pyinstaller>=5.10
+pyinstaller-hooks-contrib>=2024.10
 pyparsing==3.0.9
 requests==2.32.4
 requests-toolbelt==0.10.1

--- a/build-tools/reqs-linux.txt
+++ b/build-tools/reqs-linux.txt
@@ -11,7 +11,7 @@ docutils==0.19
 idna==3.7
 ipaddress==1.0.23
 Kivy==2.1.0
-Kivy-Garden==0.1.5
+Kivy-Garden>=0.1.5
 munch==3.0.0
 NBT==1.5.1
 nbtlib==2.0.4

--- a/build-tools/reqs-linux.txt
+++ b/build-tools/reqs-linux.txt
@@ -19,7 +19,7 @@ Pillow==10.3.0
 plyer>=2.1.0
 psutil>=6.0.0
 Pygments==2.16.1
-pyinstaller>=5.10
+pyinstaller==6.10
 pyinstaller-hooks-contrib>=2024.10
 pyparsing==3.0.9
 requests==2.32.4

--- a/build-tools/reqs-linux.txt
+++ b/build-tools/reqs-linux.txt
@@ -24,7 +24,6 @@ pyinstaller-hooks-contrib>=2024.10
 pyparsing==3.0.9
 requests==2.32.4
 requests-toolbelt==0.10.1
-simpleaudio==1.0.4
 six==1.16.0
 soupsieve==2.3.2.post1
 urllib3==1.26.20

--- a/build-tools/reqs-macos.txt
+++ b/build-tools/reqs-macos.txt
@@ -11,7 +11,7 @@ docutils==0.19
 idna==3.7
 ipaddress==1.0.23
 Kivy==2.1.0
-Kivy-Garden==0.1.5
+Kivy-Garden>=0.1.5
 munch==3.0.0
 NBT==1.5.1
 nbtlib==2.0.4

--- a/build-tools/reqs-macos.txt
+++ b/build-tools/reqs-macos.txt
@@ -19,7 +19,7 @@ Pillow==10.3.0
 plyer>=2.1.0
 psutil>=6.0.0
 Pygments==2.16.1
-pyinstaller>=5.10
+pyinstaller==6.10
 pyinstaller-hooks-contrib>=2024.7
 pyparsing==3.0.9
 requests==2.32.4

--- a/build-tools/reqs-macos.txt
+++ b/build-tools/reqs-macos.txt
@@ -10,7 +10,7 @@ dnspython==2.6.1
 docutils==0.19
 idna==3.7
 ipaddress==1.0.23
-Kivy==2.1.0
+Kivy>=2.1.0
 Kivy-Garden>=0.1.5
 munch==3.0.0
 NBT==1.5.1

--- a/build-tools/reqs-macos.txt
+++ b/build-tools/reqs-macos.txt
@@ -24,7 +24,6 @@ pyinstaller-hooks-contrib>=2024.7
 pyparsing==3.0.9
 requests==2.32.4
 requests-toolbelt==0.10.1
-simpleaudio==1.0.4
 six==1.16.0
 soupsieve==2.3.2.post1
 urllib3==1.26.20

--- a/build-tools/reqs-windows.txt
+++ b/build-tools/reqs-windows.txt
@@ -26,7 +26,7 @@ pyinstaller>=6.1.0
 pyinstaller-hooks-contrib>=2024.7
 pyparsing==3.0.9
 pypiwin32==223
-pywin32==304
+pywin32>=306
 pywin32-ctypes==0.2.2
 requests==2.32.4
 requests-toolbelt==0.10.1

--- a/build-tools/reqs-windows.txt
+++ b/build-tools/reqs-windows.txt
@@ -30,7 +30,6 @@ pywin32>=306
 pywin32-ctypes==0.2.2
 requests==2.32.4
 requests-toolbelt==0.10.1
-simpleaudio==1.0.4
 six==1.16.0
 soupsieve==2.3.2.post1
 urllib3==1.26.20

--- a/build-tools/reqs-windows.txt
+++ b/build-tools/reqs-windows.txt
@@ -9,7 +9,7 @@ dnspython==2.6.1
 docutils==0.19
 idna==3.7
 ipaddress==1.0.23
-Kivy==2.1.0
+Kivy>=2.1.0
 kivy-deps.angle>=0.3.2
 kivy-deps.glew>=0.3.1
 kivy-deps.sdl2>=0.4.5
@@ -22,7 +22,7 @@ Pillow==10.3.0
 plyer>=2.1.0
 psutil>=6.0.0
 Pygments==2.16.1
-pyinstaller==6.1.0
+pyinstaller>=6.1.0
 pyinstaller-hooks-contrib>=2024.7
 pyparsing==3.0.9
 pypiwin32==223

--- a/build-tools/reqs-windows.txt
+++ b/build-tools/reqs-windows.txt
@@ -22,7 +22,7 @@ Pillow==10.3.0
 plyer>=2.1.0
 psutil>=6.0.0
 Pygments==2.16.1
-pyinstaller>=6.1.0
+pyinstaller==6.10
 pyinstaller-hooks-contrib>=2024.7
 pyparsing==3.0.9
 pypiwin32==223

--- a/build-tools/reqs-windows.txt
+++ b/build-tools/reqs-windows.txt
@@ -10,10 +10,10 @@ docutils==0.19
 idna==3.7
 ipaddress==1.0.23
 Kivy==2.1.0
-kivy-deps.angle==0.3.2
-kivy-deps.glew==0.3.1
-kivy-deps.sdl2==0.4.5
-Kivy-Garden==0.1.5
+kivy-deps.angle>=0.3.2
+kivy-deps.glew>=0.3.1
+kivy-deps.sdl2>=0.4.5
+Kivy-Garden>=0.1.5
 munch==3.0.0
 NBT==1.5.1
 nbtlib==2.0.4

--- a/docker/README.md
+++ b/docker/README.md
@@ -163,7 +163,7 @@ Pre-requisites:
 
 - [Clone auto-mcs repo](https://github.com/macarooni-man/auto-mcs)
 - [Clone auto-mcs-ttyd repo](https://github.com/macarooni-man/auto-mcs-ttyd)
-- [Alpine Linux 3.15](https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/)
+- [Alpine Linux 3.21](https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/)
 
 After cloning the repositories on Alpine, move to the root of the `auto-mcs` repository and run the following script to build auto-mcs:
 

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -46,13 +46,13 @@ if TYPE_CHECKING:
 # ---------------------------------------------- Global Variables ------------------------------------------------------
 
 text_logo = [
-    "                           _                                 ",
-    "   ▄▄████▄▄     __ _ _   _| |_ ___       _ __ ___   ___ ___  ",
-    "  ▄█  ██  █▄   / _` | | | | __/ _ \  __ | '_ ` _ \ / __/ __| ",
-    "  ███▀  ▀███  | (_| | |_| | || (_) |(__)| | | | | | (__\__ \ ",
-    "  ▀██ ▄▄ ██▀   \__,_|\__,_|\__\___/     |_| |_| |_|\___|___/ ",
-    "   ▀▀████▀▀                                                  ",
-    "                                                             ",
+    r"                           _                                 ",
+    r"   ▄▄████▄▄     __ _ _   _| |_ ___       _ __ ___   ___ ___  ",
+    r"  ▄█  ██  █▄   / _` | | | | __/ _ \  __ | '_ ` _ \ / __/ __| ",
+    r"  ███▀  ▀███  | (_| | |_| | || (_) |(__)| | | | | | (__\__ \ ",
+    r"  ▀██ ▄▄ ██▀   \__,_|\__,_|\__\___/     |_| |_| |_|\___|___/ ",
+    r"   ▀▀████▀▀                                                  ",
+    r"                                                             ",
 ]
 
 app_title = "auto-mcs"
@@ -1349,7 +1349,7 @@ def check_app_updates() -> bool:
                 # Retrieve & parse metadata file separately
                 if name.startswith('commit-metadata'):
                     data, checksum = requests.get(url).text.split("Checksums (MD5):")
-                    dev_update_data['desc'] = re.sub('\:\s+', ':     ', data.strip())
+                    dev_update_data['desc'] = re.sub(r':\s+', ':     ', data.strip())
 
                     # Parse metadata at the top
                     for line in data.splitlines():
@@ -1988,7 +1988,7 @@ def restart_update_app(*a, with_flags: list[str] = None):
 
     new_version  = update_data['version']
     success_str  = f"auto-mcs was updated to v${new_version}$ successfully!"
-    success_unix = f"auto-mcs was updated to v\${new_version}\$ successfully!"
+    success_unix = fr"auto-mcs was updated to v\${new_version}\$ successfully!"
     failure_str  = "Something went wrong with the update"
     script_name  = 'auto-mcs-update'
     update_log   = os.path.join(paths.temp, 'update-log')
@@ -2463,14 +2463,14 @@ def translate(text: str) -> str:
 
         # Manual overrides
         if app_config.locale == 'es':
-            new_text = re.sub('servidor\.properties', 'server.properties', new_text, re.IGNORECASE)
-            new_text = re.sub('servidor\.jar', 'server.jar', new_text, re.IGNORECASE)
-            new_text = re.sub('control S', 'Administrar', new_text, re.IGNORECASE)
+            new_text = re.sub(r'servidor\.properties', 'server.properties', new_text, flags=re.IGNORECASE)
+            new_text = re.sub(r'servidor\.jar', 'server.jar', new_text, flags=re.IGNORECASE)
+            new_text = re.sub(r'control S', 'Administrar', new_text, flags=re.IGNORECASE)
         if app_config.locale == 'it':
-            new_text = re.sub(r'ESENTATO', 'ESCI', new_text, re.IGNORECASE)
+            new_text = re.sub(r'ESENTATO', 'ESCI', new_text, flags=re.IGNORECASE)
         if app_config.locale == 'fr':
-            new_text = re.sub(r'moire \(Go\)', 'moire (GB)', new_text, re.IGNORECASE)
-            new_text = re.sub(r'dos', 'retour', new_text, re.IGNORECASE)
+            new_text = re.sub(r'moire \(Go\)', 'moire (GB)', new_text, flags=re.IGNORECASE)
+            new_text = re.sub(r'dos', 'retour', new_text, flags=re.IGNORECASE)
 
 
         # Get the spacing in front and after the text
@@ -2498,12 +2498,12 @@ def translate(text: str) -> str:
             new_text = new_text.replace('$$', match, 1)
 
         # Remove dollar signs if they are still present for some reason
-        new_text = re.sub(r'\$([^\$]+)\$', '\g<1>', new_text)
+        new_text = re.sub(r'\$([^\$]+)\$', r'\g<1>', new_text)
 
         return new_text
 
     # If not, return original text
-    else: return re.sub(r'\$(.*)\$', '\g<1>', text)
+    else: return re.sub(r'\$(.*)\$', r'\g<1>', text)
 
 
 # Random splash message
@@ -2535,7 +2535,7 @@ def generate_splash(crash=False):
     ]
 
     if crash:
-        exp = re.sub('\s+',' ',splashes[randrange(len(splashes))]).strip()
+        exp = re.sub(r'\s+',' ',splashes[randrange(len(splashes))]).strip()
         return f'"{exp}"'
 
     if headless: session_splash = f"“{splashes[randrange(len(splashes))]}”"

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -2174,7 +2174,8 @@ rm \"{script_path}\"""")
 
 # Default desktop UI settings
 startup_screen:             str = 'MainMenuScreen'
-window_size:    tuple[int, int] = (850, 850)
+_default_size:  tuple[int, int] = (850, 850)
+window_size:    tuple[int, int] = _default_size
 background_color:         tuple = (0.115, 0.115, 0.182, 1)
 
 # State tracking with back button, previous screens, and previous window size

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -1,4 +1,4 @@
-from shutil import rmtree, copytree, copy, ignore_patterns, move, disk_usage
+from shutil import rmtree, copytree, copy, ignore_patterns, move, disk_usage, which
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import quote, unquote, urlparse
 from typing import TYPE_CHECKING, Any, Optional
@@ -1722,7 +1722,7 @@ def restart_move_app(*a, new_path: str, with_flags: list[str] = None):
         try: return os.path.commonpath([_canon(p), _canon(root)]) == _canon(root)
         except ValueError: return False  # different drives / UNC vs local
 
-    
+
     # Normalize inputs/paths
     new_path     = os.path.abspath(new_path)
     app_basename = os.path.basename(paths.app_folder)
@@ -2213,6 +2213,143 @@ fonts = {
     'mono-medium':  'Mono-Medium',                 'mono-bold':    'Mono-Bold',
     'mono-italic':  'SometypeMono-RegularItalic',  'icons':        'SosaRegular.ttf'
 }
+
+
+# Plays a sound for the desktop UI (pass in a relative file name)
+# Blocking will halt execution until the sound has finished
+class SoundPlayer():
+    OUT:        int = subprocess.DEVNULL
+    file:       str = None
+    blocking:  bool = False
+    _proc:  subprocess.Popen = None
+
+
+    # Internal log wrapper
+    def _send_log(self, message: str, level: str = None):
+        return send_log(self.__class__.__name__, message, level)
+
+    def __init__(self, file_name: str, blocking: bool = False):
+        path = os.path.join(paths.ui_assets, 'sounds', file_name)
+        if os.path.isfile(path): self.file = os.fspath(path)
+        self.blocking = blocking
+
+
+    # Prefer JACK when installed
+    def _jack_running(self) -> bool:
+        if os_name != 'linux': return False
+        jl = which('jack_lsp')
+        if jl:
+            try: return subprocess.run([jl], stdout=self.OUT, stderr=self.OUT).returncode == 0
+            except: pass
+        return bool(os.environ.get('JACK_DEFAULT_SERVER'))
+
+
+    def _playback_log(self, success: bool) -> bool:
+        blocking = 'blocking' if self.blocking else 'non-blocking'
+        if success: self._send_log(f"playing {blocking} sound '{self.file}'")
+        else:       self._send_log(f"failed to play sound '{self.file}'", 'error')
+        return success
+
+
+    # Run command groups
+    def _run(self, cmd: list[str]) -> bool:
+        try:
+            if self.blocking:
+                return self._playback_log(subprocess.run(cmd, stdout=self.OUT, stderr=self.OUT).returncode == 0)
+
+            self._proc = subprocess.Popen(cmd, stdout=self.OUT, stderr=self.OUT)
+            return self._playback_log(True)
+
+        except Exception as e:
+            if debug: self._send_log(f"backend {cmd[0]} failed: {e}", 'warning')
+            return False
+
+    # Plays selected sound
+    def play(self) -> bool:
+
+        if not self.file:
+            if debug: self._send_log('no sound is loaded, skipping playback', 'warning')
+            return False
+
+        if headless:
+            if debug: self._send_log("sound playback is disabled in headless", 'warning')
+            return False
+
+
+        try:
+
+            if os_name == 'windows':
+                import winsound
+                flags = winsound.SND_FILENAME | (0 if self.blocking else winsound.SND_ASYNC)
+                winsound.PlaySound(self.file, flags)
+                return self._playback_log(True)
+
+
+            elif os_name == 'macos':
+                cmd = ["afplay", self.file]
+                return self._run(cmd)
+
+
+            # Linux
+            else:
+                # Spray and pray honestly, lol
+                candidates = []
+
+                # Prefer JACK if its server is online
+                if self._jack_running():
+                    if which("jack_play"):   candidates.append(["jack_play"])
+                    elif which("jack-play"): candidates.append(["jack-play"])
+                    if which("mpv"):         candidates.append(["mpv", "--no-video", "--really-quiet", "--ao=jack"])
+                    if which("cvlc"):        candidates.append(["cvlc", "--play-and-exit", "--intf", "dummy", "--aout", "jack"])
+
+                    # Works only if ALSA JACK plugin/device "jack" exists
+                    if which("aplay"):       candidates.append(["aplay", "-D", "jack"])
+
+                candidates += [
+                    ["pw-play"],                                         # PipeWire
+                    ["paplay"],                                          # PulseAudio / PipeWire
+                    ["pw-cat", "--playback"],                            # PipeWire
+                    ["canberra-gtk-play", "-f"],                         # libcanberra
+                    ["aplay"],                                           # ALSA
+                    ["play"],                                            # SoX
+                    ["ffplay", "-v", "quiet", "-nodisp", "-autoexit"],   # ffmpeg
+                    ["cvlc", "--play-and-exit", "--intf", "dummy"],
+                ]
+
+                for cmd in candidates:
+                    if which(cmd[0]):
+                        cmd.append(self.file)
+                        if self._run(cmd): return True
+
+
+        except Exception as e:
+            self._send_log(f"error playing '{self.file}': {format_traceback(e)}", 'error')
+            return False
+
+        return self._playback_log(False)
+
+
+    # Stops selected sound
+    def stop(self) -> bool:
+        try:
+            if os_name == 'windows':
+                import winsound
+                winsound.PlaySound(None, winsound.SND_PURGE)
+                self._proc = None
+                return True
+
+            # macOS/Linux: kill the player process if it's still running
+            elif self._proc and self._proc.poll() is None:
+                self._proc.terminate()
+                try: self._proc.wait(timeout=0.5)
+                except subprocess.TimeoutExpired: self._proc.kill()
+
+            self._proc = None
+            return True
+
+        except Exception as e:
+            if debug: self._send_log(f"error stopping sound: {format_traceback(e)}", 'warning')
+            return False
 
 
 # Set by the respective UI to prevent the app from being closed

--- a/source/core/server/amscript.py
+++ b/source/core/server/amscript.py
@@ -721,7 +721,7 @@ class ScriptObject():
                     if (line.startswith("@")) and line.strip()[-1] != ":": # func_call == line.strip() or
                         func_calls.append(f'{line.strip()}\n')
 
-                    elif not (line.strip().startswith('@') and line.strip().endswith(':')): # elif re.match(r"[A-Za-z0-9]+.*=.*", line.strip(), re.IGNORECASE)
+                    elif not (line.strip().startswith('@') and line.strip().endswith(':')): # elif re.match(r"[A-Za-z0-9]+.*=.*", line.strip(), flags=re.IGNORECASE)
                         func_calls.append(line.strip() + "\n")
 
                 script_data = script_data + line

--- a/source/core/server/amscript.py
+++ b/source/core/server/amscript.py
@@ -5,7 +5,6 @@ from textwrap import indent
 from copy import deepcopy
 from munch import Munch
 from glob import glob
-import sysconfig
 import traceback
 import functools
 import datetime
@@ -2839,22 +2838,7 @@ id_dict = {
 
 
 # Retrieve Python standard libraries for module whitelist
-std_lib = sysconfig.get_python_lib(standard_lib=True)
-libs = []
-for top, dirs, files in os.walk(std_lib):
-    for nm in files:
-        prefix = top[len(std_lib)+1:]
-        if prefix[:13] == 'site-packages':
-            continue
-        if nm == '__init__.py':
-            libs.append(top[len(std_lib)+1:].replace(os.path.sep,'.'))
-        elif nm[-3:] == '.py':
-            libs.append(os.path.join(prefix, nm)[:-3].replace(os.path.sep,'.'))
-        elif nm[-3:] == '.so' and top[-11:] == 'lib-dynload':
-            libs.append(nm[0:-3])
-
-for builtin in sys.builtin_module_names:
-    libs.append(builtin)
+libs = sorted(set(sys.stdlib_module_names) | set(sys.builtin_module_names))
 
 # Filter out libraries
 std_libs = []

--- a/source/core/server/amscript.py
+++ b/source/core/server/amscript.py
@@ -1,4 +1,3 @@
-import distutils.sysconfig as sysconfig
 from datetime import datetime as dt
 from difflib import SequenceMatcher
 from threading import Timer
@@ -6,6 +5,7 @@ from textwrap import indent
 from copy import deepcopy
 from munch import Munch
 from glob import glob
+import sysconfig
 import traceback
 import functools
 import datetime
@@ -422,7 +422,7 @@ class ScriptObject():
         self.valid_events = ["@player.on_join", "@player.on_leave", "@player.on_death", "@player.on_message", "@player.on_achieve", "@server.on_start", "@server.on_stop", "@player.on_alias", "@server.on_loop"]
         self.delay_events = ["@player.on_join", "@player.on_leave", "@player.on_death", "@player.on_message", "@player.on_achieve", "@server.on_start", "@server.on_stop"]
         self.valid_imports = std_libs
-        for library in ['dataclasses', 'itertools', 'requests', 'bs4', 'nbt', 'tkinter', 'simpleaudio', 'webbrowser', 'cloudscraper', 'json', 'difflib', 'shutil', 'concurrent', 'concurrent.futures', 'random', 'platform', 'threading', 'copy', 'glob', 'configparser', 'unicodedata', 'subprocess', 'functools', 'threading', 'requests', 'datetime', 'tarfile', 'zipfile', 'hashlib', 'urllib', 'string', 'psutil', 'socket', 'time', 'json', 'math', 'sys', 'os', 're', 'pathlib', 'ctypes', 'inspect', 'functools', 'PIL', 'base64', 'ast', 'traceback', 'munch', 'textwrap', 'urllib', 'asyncio']:
+        for library in ['dataclasses', 'itertools', 'requests', 'bs4', 'nbt', 'tkinter', 'webbrowser', 'cloudscraper', 'json', 'difflib', 'shutil', 'concurrent', 'concurrent.futures', 'random', 'platform', 'threading', 'copy', 'glob', 'configparser', 'unicodedata', 'subprocess', 'functools', 'threading', 'requests', 'datetime', 'tarfile', 'zipfile', 'hashlib', 'urllib', 'string', 'psutil', 'socket', 'time', 'json', 'math', 'sys', 'os', 're', 'pathlib', 'ctypes', 'inspect', 'functools', 'PIL', 'base64', 'ast', 'traceback', 'munch', 'textwrap', 'urllib', 'asyncio']:
             if library not in self.valid_imports:
                 self.valid_imports.append(library)
 

--- a/source/core/server/foundry.py
+++ b/source/core/server/foundry.py
@@ -2608,10 +2608,10 @@ def scan_modpack(update=False, progress_func=None):
                 data['launch_flags'] = content['launch']['javaArgs']
 
                 matches = {'forge': 0, 'fabric': 0, 'neoforge': 0, 'quilt': 0}
-                matches['forge'] += len(re.findall(r'\bforge\b', raw_content, re.IGNORECASE))
-                matches['fabric'] += len(re.findall(r'\bfabric\b', raw_content, re.IGNORECASE))
-                matches['neoforge'] += len(re.findall(r'\bneoforge\b', raw_content, re.IGNORECASE))
-                matches['quilt'] += len(re.findall(r'\bquilt\b', raw_content, re.IGNORECASE))
+                matches['forge'] += len(re.findall(r'\bforge\b', raw_content, flags=re.IGNORECASE))
+                matches['fabric'] += len(re.findall(r'\bfabric\b', raw_content, flags=re.IGNORECASE))
+                matches['neoforge'] += len(re.findall(r'\bneoforge\b', raw_content, flags=re.IGNORECASE))
+                matches['quilt'] += len(re.findall(r'\bquilt\b', raw_content, flags=re.IGNORECASE))
                 data['type'] = 'fabric' if matches['fabric'] > matches['forge'] else 'forge'
                 if data['type'] == 'fabric' and matches['quilt'] > 1:
                     data['type'] = 'quilt'
@@ -2786,10 +2786,10 @@ def scan_modpack(update=False, progress_func=None):
         }
 
         def process_matches(content):
-            matches['forge'] += len(re.findall(r'\bforge\b', content, re.IGNORECASE))
-            matches['fabric'] += len(re.findall(r'\bfabric\b', content, re.IGNORECASE))
-            matches['neoforge'] += len(re.findall(r'\bneoforge\b', content, re.IGNORECASE))
-            matches['quilt'] += len(re.findall(r'\bquilt\b', content, re.IGNORECASE))
+            matches['forge'] += len(re.findall(r'\bforge\b', content, flags=re.IGNORECASE))
+            matches['fabric'] += len(re.findall(r'\bfabric\b', content, flags=re.IGNORECASE))
+            matches['neoforge'] += len(re.findall(r'\bneoforge\b', content, flags=re.IGNORECASE))
+            matches['quilt'] += len(re.findall(r'\bquilt\b', content, flags=re.IGNORECASE))
             matches['versions'].extend(re.findall(r'(?<!\d.)1\.\d\d?\.\d\d?(?!\.\d+)\b', content))
 
         # First, search through all the files to find the type, version, and launch flags

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -2567,9 +2567,12 @@ class ServerManager():
             raise e
 
     # Retrieve a server object without setting it as the active "current_server"
-    def get_server(self, name: str) -> ServerObject:
-        if not self.server_list_lower: self.create_server_list()
-        if name.lower() not in self.server_list_lower: raise self.NoServerError(name)
+    def get_server(self, name: str, _regen_list: bool = True) -> ServerObject:
+        if name.lower() not in self.server_list_lower:
+            if _regen_list:
+                self.create_server_list()
+                return self.get_server(name, False)
+            raise self.NoServerError(name)
 
         # If current server already matches, just use it
         if getattr(self, "current_server", None) and self.current_server.name == name:

--- a/source/launcher.py
+++ b/source/launcher.py
@@ -174,8 +174,8 @@ def get_system_context():
         if constants.os_name == 'macos': system_locale = constants.run_proc("osascript -e 'user locale of (get system info)'", True, log_only_in_debug=True)
 
         else:
-            from locale import getdefaultlocale
-            system_locale = getdefaultlocale()[0]
+            import locale
+            system_locale = locale.getlocale()[0]
 
         if '_' in system_locale: system_locale = system_locale.split('_')[0]
 
@@ -599,8 +599,7 @@ if __name__ == '__main__':
 
 
     # Launch & threading logic
-    background_thread = threading.Thread(name='background', target=background)
-    background_thread.setDaemon(True)
+    background_thread = threading.Thread(name='background', target=background, daemon=True)
 
     background_thread.start()
     foreground()

--- a/source/ui/amseditor.py
+++ b/source/ui/amseditor.py
@@ -3239,7 +3239,7 @@ def launch_window(path: str, data: dict, *a):
 
                 if regex:
                     try:
-                        compiled = re.compile(pattern, re.IGNORECASE)
+                        compiled = re.compile(pattern, flags=re.IGNORECASE)
                         return pattern, True
                     except re.error as e:
                         # Fallback to escaped pattern to treat it as literal
@@ -3284,9 +3284,9 @@ def launch_window(path: str, data: dict, *a):
                 # Compile the regex pattern
                 try:
                     if is_regex:
-                        compiled_pattern = re.compile(sanitized_pattern, re.IGNORECASE)
+                        compiled_pattern = re.compile(sanitized_pattern, flags=re.IGNORECASE)
                     else:
-                        compiled_pattern = re.compile(sanitized_pattern, re.IGNORECASE)
+                        compiled_pattern = re.compile(sanitized_pattern, flags=re.IGNORECASE)
                 except re.error as e:
                     # Inform the user about the invalid pattern
                     self.error_label.configure(text=f"Invalid search pattern: {e}")

--- a/source/ui/amseditor.py
+++ b/source/ui/amseditor.py
@@ -4862,6 +4862,7 @@ def ipc_save_script(cache_dir: str, script_path: str, script_contents: str, ipc_
 # Change DPI scaling context on Windows
 if os.name == 'nt':
     from ctypes import windll, c_int64
+    os.environ["SDL_WINDOWS_DPI_AWARENESS"] = "unaware"
 
     # Calculate screen width and disable DPI scaling if bigger than a certain resolution
     try:

--- a/source/ui/crashmgr.py
+++ b/source/ui/crashmgr.py
@@ -1,7 +1,7 @@
 import functools
 import os
 
-from source.core.constants import paths
+from source.core.constants import paths, SoundPlayer
 from source.core import constants
 
 
@@ -10,7 +10,6 @@ from source.core import constants
 if not constants.headless:
     from tkinter import Tk, Entry, SUNKEN, Canvas, PhotoImage, CENTER, END
     from PIL import ImageTk, Image
-    import simpleaudio as sa
 
     from source.ui import logviewer
 
@@ -55,7 +54,7 @@ def launch_window(exc_code, log_path):
 
 
     # Init Tk window
-    crash_sound = sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', 'crash.wav'))
+    crash_sound = SoundPlayer('crash.wav')
     background_color = constants.convert_color(constants.background_color)['hex']
     crash_assets = os.path.join(paths.ui_assets, 'crash-assets')
     text_color = constants.convert_color((0.6, 0.6, 1))['hex']

--- a/source/ui/desktop.py
+++ b/source/ui/desktop.py
@@ -2,8 +2,6 @@ from PIL.ImageFilter import GaussianBlur
 from datetime import datetime as dt
 from PIL import Image as PILImage
 from ctypes import ArgumentError
-
-from numpy.version import full_version
 from pypresence import Presence
 from plyer import filechooser
 from random import randrange

--- a/source/ui/desktop.py
+++ b/source/ui/desktop.py
@@ -358,7 +358,7 @@ def scale_size(obj, o, n, *a):
             obj.font_size = obj.__o_size__ - new_size
 def filter_text(string):
     if isinstance(string, str) and "$" in string:
-        return re.sub(r'\$([^\$]+)\$', '\g<1>', string)
+        return re.sub(r'\$([^\$]+)\$', r'\g<1>', string)
     else:
         return string
 class Label(Label):
@@ -3404,8 +3404,8 @@ class ServerFlagInput(BaseInput):
             (f.strip().startswith('<java') and f.strip().endswith('>'))
             for f in typed_info.split(' ')
         ])
-        space_check = re.search(r'(-\s|\w-\s|\d-| \s+|-+$)', typed_info, re.IGNORECASE)
-        memory_check = re.search(r'-xm(x|s)\d+(b|k|m|g|t)', typed_info, re.IGNORECASE)
+        space_check = re.search(r'(-\s|\w-\s|\d-| \s+|-+$)', typed_info, flags=re.IGNORECASE)
+        memory_check = re.search(r'-xm(x|s)\d+(b|k|m|g|t)', typed_info, flags=re.IGNORECASE)
         self.stinky_text = ''
 
         if typed_info:
@@ -11823,7 +11823,7 @@ class AclRulePanel(RelativeLayout):
                         ), 0
                     )
 
-                    Clipboard.copy(re.sub("\[.*?\]","",self.text))
+                    Clipboard.copy(re.sub(r"\[.*?\]","",self.text))
 
 
             def ref_text(self, *args):
@@ -15567,7 +15567,7 @@ class ServerButton(HoverButton):
         def on_ref_press(self, *args):
             if not self.disabled:
                 def click(*a):
-                    clipboard_text = re.sub("\[.*?\]", "", self.text.split(" ")[-1].strip())
+                    clipboard_text = re.sub(r"\[.*?\]", "", self.text.split(" ")[-1].strip())
                     if self.parent.button_pressed == "left":
                         banner_text = "Copied IP address  (right-click for LAN)"
 
@@ -16257,7 +16257,7 @@ class ServerButton(HoverButton):
             Clock.schedule_once(delete_button.button.trigger_action, 0.1)
         def copy_ip(local, *a):
                 def click(*a):
-                    clipboard_text = re.sub("\[.*?\]", "", self.subtitle.text.split(" ")[-1].strip())
+                    clipboard_text = re.sub(r"\[.*?\]", "", self.subtitle.text.split(" ")[-1].strip())
                     if not local:
                         banner_text = "Copied IP address"
 
@@ -17432,7 +17432,7 @@ class PerformancePanel(RelativeLayout):
                                 # Functions for context menu
                                 def permissions(*a):
                                     if constants.server_manager.current_server.acl:
-                                        constants.server_manager.current_server.acl.get_rule(re.sub("\[.*?\]", "", username))
+                                        constants.server_manager.current_server.acl.get_rule(re.sub(r"\[.*?\]", "", username))
                                         constants.back_clicked = True
                                         screen_manager.current = 'ServerAclScreen'
                                         constants.back_clicked = False
@@ -17572,7 +17572,7 @@ class PerformancePanel(RelativeLayout):
                         def click_func(*a):
                             if not self.button.ignore_hover and self.label.text and self.button.last_touch.button == 'left':
                                 if constants.server_manager.current_server.acl:
-                                    constants.server_manager.current_server.acl.get_rule(re.sub("\[.*?\]", "", self.label.text))
+                                    constants.server_manager.current_server.acl.get_rule(re.sub(r"\[.*?\]", "", self.label.text))
                                     constants.back_clicked = True
                                     screen_manager.current = 'ServerAclScreen'
                                     constants.back_clicked = False
@@ -23543,7 +23543,7 @@ class ConfigFolder(RelativeLayout):
             return f'[color={color}]{parent}/[/color]{child}'
         elif '\\' in text:
             parent, child = text.rsplit('\\', 1)
-            return f'[color={color}]{parent}\[/color]{child}'
+            return fr'[color={color}]{parent}\[/color]{child}'
         else:
             return text.strip()
 
@@ -23667,11 +23667,12 @@ class ConfigFiles(GridLayout):
             self.text.x = 48 + self.padding
             self.add_widget(self.text)
 
-        def resize(self, *a):
-            self.padding = 10 if Window.width < 900 else 100
+        def resize(self, *a, folder=None):
+            self.padding = (10 if Window.width < 900 else 60) - 5
             self.button.x = self.padding
             self.icon.x = self.padding
             self.text.x = 48 + self.padding
+            if folder: self.text.size_hint_max_x = (folder.parent.background.size_hint_min_x - self.text.x) / 2.3
 
         def on_click(self):
             new_color = (0.75, 0.75, 1, 1)
@@ -23694,10 +23695,11 @@ class ConfigFiles(GridLayout):
             Animation(opacity=self.original_opacity, duration=self.hover_delay).start(self.icon)
 
     def resize_files(self, *a):
-        for file in self.children:
-            file.resize()
-
         self.folder.parent.background.size_hint_min_x = screen_manager.current_screen.max_width + (10 if Window.width < 900 else 60)
+
+        for file in self.children:
+            file.resize(folder=self.folder)
+
         Animation.stop_all(self.folder.parent.background)
         Animation(opacity=(0 if self.folder.folded else 1), duration=0.15).start(self.folder.parent.background)
 
@@ -23761,13 +23763,14 @@ class ServerConfigScreen(MenuBackground):
         super().__init__(**kwargs)
         self.name = self.__class__.__name__
         self.menu = 'init'
-
+        
+        self.filter_text: str = ''
+        self.max_width:   int = None
         self.server_obj = None
         self.scroll_widget = None
         self.scroll_anchor = None
         self.scroll_layout = None
         self.header = None
-        self.filter_text = ''
         self.search_bar = None
         self.search_label = None
         self.back_button = None

--- a/source/ui/desktop.py
+++ b/source/ui/desktop.py
@@ -28560,7 +28560,7 @@ class TelepathInstanceScreen(MenuBackground):
         self.load_layout = FloatLayout(opacity=0)
 
         # Loading icon to swap button
-        self.load_layout.icon = Image()
+        self.load_layout.icon = AsyncImage()
         self.load_layout.icon.id = "load_icon"
         self.load_layout.icon.source = os.path.join(paths.ui_assets, 'animations', 'loading_pickaxe.gif')
         self.load_layout.icon.size_hint_max = (50, 50)
@@ -29453,7 +29453,7 @@ class TelepathManagerScreen(MenuBackground):
             self.pair_layout.add_widget(self.host_input)
 
             # Spinning pickaxe
-            load_icon = Image()
+            load_icon = AsyncImage()
             load_icon.id = "load_icon"
             load_icon.source = os.path.join(paths.ui_assets, 'animations', 'loading_pickaxe.gif')
             load_icon.size_hint_max = (self.host_input.height / 2.5, self.host_input.height / 2.5)
@@ -29509,7 +29509,7 @@ class TelepathManagerScreen(MenuBackground):
 
 
             # Spinning pickaxe
-            load_icon = Image()
+            load_icon = AsyncImage()
             load_icon.id = "load_icon"
             load_icon.source = os.path.join(paths.ui_assets, 'animations', 'loading_pickaxe.gif')
             load_icon.size_hint_max = (self.host_input.height, self.host_input.height)

--- a/source/ui/desktop.py
+++ b/source/ui/desktop.py
@@ -30007,6 +30007,7 @@ class MainApp(App):
         if constants.app_config.fullscreen:
             Window.maximize()
         Window.show()
+        Window._update_density_and_dpi()
 
         # Raise window
         def raise_window(*a):

--- a/source/ui/desktop.py
+++ b/source/ui/desktop.py
@@ -8513,8 +8513,14 @@ def button_action(button_name, button, specific_screen=''):
 
 # Template for any screen
 def save_window_pos(*args):
+
+    # Only save position in windowed mode
     if Window.left > 0 and Window.top > 0:
-        constants.last_window = {'pos': [Window.left, Window.top], 'size': Window.system_size}
+        constants.last_window.update({'pos': [Window.left, Window.top], 'size': Window.system_size})
+
+    constants.app_config.fullscreen = (Window.system_size[0] > (constants._default_size[0] + 400))
+    constants.app_config.geometry   = constants.last_window
+
 class MenuBackground(Screen):
 
     reload_page = True
@@ -29931,20 +29937,20 @@ class MainApp(App):
 
     # Window size
     if not preconfigured:
-        size = constants.window_size
+        size = constants._default_size
 
         # Get pos and knowing the old size calculate the new one
-        top = dp((Window.top * Window.size[1] / size[1])) - dp(70)
+        top  = dp((Window.top * Window.size[1] / size[1])) - dp(70)
         left = dp(Window.left * Window.size[0] / size[0])
 
         Window.size = (dp(size[0]), dp(size[1]))
-        Window.top = top
+        Window.top  = top
         Window.left = left
     Window.on_request_close = exit_app
 
-    Window.minimum_width = constants.window_size[0]
+    Window.minimum_width  = constants.window_size[0]
     Window.minimum_height = constants.window_size[1] - 50
-    Window.clearcolor = constants.background_color
+    Window.clearcolor     = constants.background_color
     Builder.load_string(kv_file)
 
     # Prevent window from closing during certain situations
@@ -29952,8 +29958,6 @@ class MainApp(App):
 
         # Write window size to global config
         save_window_pos()
-        constants.app_config.fullscreen = (Window.width > (constants.window_size[0] + 400))
-        constants.app_config.geometry = constants.last_window
 
         if force_close:
             Window.close()
@@ -29977,7 +29981,11 @@ class MainApp(App):
         if not data: exit_app()
         return data
     Window.bind(on_request_close=_close_window_wrapper)
-    Window.bind(on_cursor_enter=save_window_pos, on_cursor_leave=save_window_pos)
+    Window.bind(
+        on_maximize     = save_window_pos,
+        on_minimize     = save_window_pos,
+        on_restore      = save_window_pos
+    )
     dropped_files = []
     processing_drops = False
 

--- a/source/ui/desktop.py
+++ b/source/ui/desktop.py
@@ -8,7 +8,6 @@ from pypresence import Presence
 from plyer import filechooser
 from random import randrange
 from PIL import ImageEnhance
-import simpleaudio as sa
 from pathlib import Path
 from glob import glob
 import webbrowser
@@ -29,9 +28,9 @@ import re
 
 # Local imports
 from source.core.server import foundry, manager, amscript, addons, backup, acl
+from source.core.constants import paths, SoundPlayer
 from source.core import constants, telepath, logger
 from source.ui import amseditor, logviewer
-from source.core.constants import paths
 
 
 # UI log wrapper
@@ -6439,7 +6438,7 @@ class PopupInfo(PopupWindow):
         super().__init__(**kwargs)
 
         # Modal specific settings
-        self.window_sound = sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', 'popup_normal.wav'))
+        self.window_sound = SoundPlayer('popup_normal.wav')
         self.no_button = None
         self.yes_button = None
         with self.canvas.after:
@@ -6473,7 +6472,7 @@ class PopupWarning(PopupWindow):
         super().__init__(**kwargs)
 
         # Modal specific settings
-        self.window_sound = sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', 'popup_warning.wav'))
+        self.window_sound = SoundPlayer('popup_warning.wav')
         self.no_button = None
         self.yes_button = None
         with self.canvas.after:
@@ -6507,7 +6506,7 @@ class PopupQuery(PopupWindow):
         super().__init__(**kwargs)
 
         # Modal specific settings
-        self.window_sound = sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', 'popup_normal.wav'))
+        self.window_sound = SoundPlayer('popup_normal.wav')
         self.ok_button = None
         with self.canvas.after:
             self.no_button = Button()
@@ -6556,7 +6555,7 @@ class PopupWarningQuery(PopupWindow):
         super().__init__(**kwargs)
 
         # Modal specific settings
-        self.window_sound = sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', 'popup_warning.wav'))
+        self.window_sound = SoundPlayer('popup_warning.wav')
         self.ok_button = None
         with self.canvas.after:
             self.no_button = Button()
@@ -6605,7 +6604,7 @@ class PopupErrorLog(PopupWindow):
         super().__init__(**kwargs)
 
         # Modal specific settings
-        self.window_sound = sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', 'popup_warning.wav'))
+        self.window_sound = SoundPlayer('popup_warning.wav')
         self.ok_button = None
         with self.canvas.after:
             self.no_button = Button()
@@ -6734,7 +6733,7 @@ class PopupTelepathPair(PopupWindow):
 
         # Modal specific settings
         self.window_title.text = title
-        self.window_sound = sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', window_sound))
+        self.window_sound = SoundPlayer(window_sound)
         self.no_button = None
         self.yes_button = None
         with self.canvas.after:
@@ -7507,7 +7506,7 @@ class PopupUpdate(BigPopupWindow):
 
 
         # Modal specific settings
-        self.window_sound = sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', 'popup_normal.wav'))
+        self.window_sound = SoundPlayer('popup_normal.wav')
         self.ok_button = None
         with self.canvas.after:
 
@@ -8883,10 +8882,8 @@ class MenuBackground(Screen):
         Clock.schedule_once(functools.partial(hide_banner, banner_layout), duration + 0.32)
 
         if play_sound:
-            try:
-                sa.WaveObject.from_wave_file(os.path.join(paths.ui_assets, 'sounds', play_sound)).play()
-            except:
-                pass
+            try: SoundPlayer(play_sound).play()
+            except: pass
 
 
     # Keyboard listeners

--- a/source/ui/headless.py
+++ b/source/ui/headless.py
@@ -2010,7 +2010,7 @@ class PropertiesEditor():
 
     def highlight_text(self, text, term, default_attr=None):
         # Split the text into parts where the term occurs (case-insensitive)
-        regex = re.compile('(' + re.escape(term) + ')', re.IGNORECASE)
+        regex = re.compile('(' + re.escape(term) + ')', flags=re.IGNORECASE)
         parts = regex.split(text)
         # Apply highlighting to the matched terms
         result = []

--- a/source/ui/logviewer.py
+++ b/source/ui/logviewer.py
@@ -467,6 +467,7 @@ def open_log(server_name: str, path: str, data: dict, *args):
 
 if os.name == 'nt':
     from ctypes import windll, c_int64
+    os.environ["SDL_WINDOWS_DPI_AWARENESS"] = "unaware"
 
     # Calculate screen width and disable DPI scaling if bigger than a certain resolution
     try:

--- a/source/ui/main.py
+++ b/source/ui/main.py
@@ -1,5 +1,6 @@
 from source.core.server.manager import ServerManager
 from source.core import constants, logger
+import os
 
 
 # Logging wrapper
@@ -14,6 +15,7 @@ def ui_loop():
     if constants.os_name == "windows" and not constants.headless:
         from ctypes import windll, c_int64
         send_log('ui_loop', f'setting DPI context before launching GUI')
+        os.environ["SDL_WINDOWS_DPI_AWARENESS"] = "unaware"
 
         # Calculate screen width and disable DPI scaling if bigger than a certain resolution
         try:


### PR DESCRIPTION
Open PR for #122

The goal of this PR is to maintain identical functionality for prior releases, but on the base of Python 3.12 instead of 3.9.

The reason for this is because Python 3.9 is losing support next month and this needs to be addressed. 3.12 appears to be a stable choice due to support from bigger libraries, and it's not entirely bleeding edge.

Syntax changes to the source code that embrace the update are expected in the future, but will not be added in this PR.

- Still need to fix all invalid escape sequences