### PR TITLE
Add-on Manager updates fix

### DIFF
--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -372,7 +372,6 @@ class AddonManager():
 
                     # Everything else
                     update = get_update_url(addon, self._server['version'], self._server['type'])
-                    print(addon.addon_version, update.addon_version)
                     if constants.check_app_version(addon.addon_version, update.addon_version, limit=3):
                         # print(addon.name, addon.addon_version, update.addon_version)
                         self.update_required = True

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -638,7 +638,7 @@ def get_addon_file(addon_path: str, server_properties, enabled=False):
             except:
                 try:
                     a = addon_version.replace('_', ' ').replace('-', ' ')
-                    addon_versions = re.sub("([^0-9.\s]+)", "", addon_version).split(' ')
+                    addon_versions = re.sub(r'([^0-9.\s]+)', '', addon_version).split(' ')
                 except: pass
 
             # Find the most likely version from regex matches

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -372,6 +372,7 @@ class AddonManager():
 
                     # Everything else
                     update = get_update_url(addon, self._server['version'], self._server['type'])
+                    print(addon.addon_version, update.addon_version)
                     if constants.check_app_version(addon.addon_version, update.addon_version, limit=3):
                         # print(addon.name, addon.addon_version, update.addon_version)
                         self.update_required = True
@@ -417,6 +418,7 @@ def get_addon_file(addon_path: str, server_properties, enabled=False):
 
     # Determine which addons to look for
     server_type = manager.parse_server_type(server_properties['type'])
+    server_version = server_properties['version']
 
     # Get addon information
     if jar_name.endswith(".jar"):
@@ -521,14 +523,12 @@ def get_addon_file(addon_path: str, server_properties, enabled=False):
                         # If mcmod.info is absent, check mods.toml/neoforge.mods.toml
                         if not addon_name:
                             try:
-                                try:
-                                    jar_file.extract('META-INF/mods.toml', addon_tmp)
-                                except:
-                                    pass
-                                try:
-                                    jar_file.extract('META-INF/neoforge.mods.toml', addon_tmp)
-                                except:
-                                    pass
+                                try: jar_file.extract('META-INF/mods.toml', addon_tmp)
+                                except: pass
+
+                                try: jar_file.extract('META-INF/neoforge.mods.toml', addon_tmp)
+                                except: pass
+
                                 for file in glob(os.path.join(addon_tmp, 'META-INF', '*mods.toml')):
                                     with open(file, 'r', encoding='utf-8', errors='ignore') as toml:
                                         addon_type = server_type
@@ -633,14 +633,19 @@ def get_addon_file(addon_path: str, server_properties, enabled=False):
                     addon_author = None
 
 
-            # If information was not found, use file name instead
-            try:
-                addon_version = re.search(r'\d+(\.\d+)+', addon_version).group(0)
+            # Attempt to parse proper addon versions from a potential list
+            addon_versions = []
+            try: addon_versions = re.findall(r'(\d+[\.\d+]+)', addon_version)
             except:
                 try:
-                    addon_version = re.sub("[^0-9|.]", "", addon_version.split(' ')[0])
-                except:
-                    pass
+                    a = addon_version.replace('_', ' ').replace('-', ' ')
+                    addon_versions = re.sub("([^0-9.\s]+)", "", addon_version).split(' ')
+                except: pass
+
+            # Find the most likely version from regex matches
+            if addon_versions:
+                if server_version in addon_versions and len(addon_versions) > 1: addon_versions.remove(server_version)
+                addon_version = addon_versions[0]
 
             if not addon_name:
 
@@ -676,8 +681,8 @@ def get_addon_file(addon_path: str, server_properties, enabled=False):
             }
 
         return AddonObj
-    else:
-        return None
+
+    else: return None
 
 
 # Imports addon to server

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -1057,9 +1057,11 @@ def get_update_url(addon: AddonFileObject, new_version: str, force_type=None):
         if constants.get_url(potential_url, return_response=True).status_code in [200, 302]:
             addon_url = potential_url
 
-    # If id is absent, make a search for the name
+    # If id is absent, make a search for the filtered name
     if addon.name and not addon_url:
-        potential_url = project_urls[new_type] + addon.name
+        filtered = re.sub(r'[^A-Za-z _+-]+', '', addon.name)
+        filtered = re.sub(r'\s+', '-', filtered).lower()
+        potential_url = project_urls[new_type] + filtered
         if constants.get_url(potential_url, return_response=True).status_code in [200, 302]:
             addon_url = potential_url
 

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -2831,7 +2831,7 @@ class ServerManager():
         # Log update list
         log_list = [name for name, data in self.update_list.items() if data]
         if log_list: self._send_log(f"updates are available for:\n{log_list}", 'info')
-        else:                self._send_log('all servers are up to date', 'info')
+        else:        self._send_log('all servers are up to date', 'info')
 
         return self.update_list
 

--- a/source/ui/desktop/widgets/inputs.py
+++ b/source/ui/desktop/widgets/inputs.py
@@ -264,7 +264,7 @@ class SearchBar(FloatLayout):
                 substring = ""
 
             elif len(self.text) < 50:
-                s = re.sub('[^a-zA-Z0-9 _().-]', '', substring.splitlines()[0])
+                s = re.sub('[^a-zA-Z0-9 _()\'\".-]', '', substring.splitlines()[0])
 
                 return super().insert_text(s, from_undo=from_undo)
 


### PR DESCRIPTION
The add-on manager sometimes cached the wrong version in the filename as a fallback. This is prevalent with a name like `supercoolmod_1.21.11_v2.4.3.jar` where it's possible to cache the Minecraft version instead of the add-on version.

This fix improves the heuristics to use a list instead of a single match, and exclude any versions that match the Minecraft version unless the list has a length of 1. This makes it less likely to cause a conflict, but the issue itself is simply a limitation of heuristics. It's possible there's a better algorithm for this, but it's an edge case for a fallback. Generally, mods have a specific config file within that documents the version explicitly so this isn't usually an issue.