### PR TITLE
QOL: Show (<15GB) wherever check_free_space() is called and a message shown

### DIFF
--- a/source/ui/desktop/utility.py
+++ b/source/ui/desktop/utility.py
@@ -1270,7 +1270,7 @@ def disk_popup(go_to='back', telepath_data=None):
             screen_manager.current_screen.show_popup(
                 "warning",
                 "Storage Error",
-                f"auto-mcs has limited functionality from low disk space. Further changes can lead to corruption in your servers.\n\nPlease free up space on {'this $Telepath$ instance' if telepath_data else 'your disk'} to continue",
+                f"auto-mcs has limited functionality from low disk space (<15GB). Further changes can lead to corruption in your servers.\n\nPlease free up space on {'this $Telepath$ instance' if telepath_data else 'your disk'} to continue",
                 go_back
             )
 

--- a/source/ui/desktop/views/server/create.py
+++ b/source/ui/desktop/views/server/create.py
@@ -1389,7 +1389,7 @@ class CreateServerProgressScreen(ProgressScreen):
                 self.execute_error("An internet connection is required to continue\n\nVerify connectivity and try again")
 
             elif not constants.check_free_space(telepath_data=foundry.new_server_info['_telepath_data']):
-                self.execute_error("Your primary disk is almost full\n\nFree up space and try again")
+                self.execute_error("Your primary disk is almost full (<15GB)\n\nFree up space and try again")
 
             else:
                 foundry.pre_server_create()

--- a/source/ui/desktop/views/server/import.py
+++ b/source/ui/desktop/views/server/import.py
@@ -137,7 +137,7 @@ class ServerImportProgressScreen(ProgressScreen):
                 self.execute_error("An internet connection is required to continue\n\nVerify connectivity and try again")
 
             elif not constants.check_free_space(telepath_data=foundry.new_server_info['_telepath_data']):
-                self.execute_error("Your primary disk is almost full\n\nFree up space and try again")
+                self.execute_error("Your primary disk is almost full (<15GB)\n\nFree up space and try again")
 
             else: foundry.pre_server_create()
 
@@ -286,7 +286,7 @@ class ServerImportModpackProgressScreen(ProgressScreen):
                 self.execute_error("An internet connection is required to continue\n\nVerify connectivity and try again")
 
             elif not constants.check_free_space(telepath_data=foundry.new_server_info['_telepath_data']):
-                self.execute_error("Your primary disk is almost full\n\nFree up space and try again")
+                self.execute_error("Your primary disk is almost full (<15GB)\n\nFree up space and try again")
 
             else: foundry.pre_server_create()
 

--- a/source/ui/desktop/views/server/manager/addons.py
+++ b/source/ui/desktop/views/server/manager/addons.py
@@ -862,7 +862,7 @@ class ServerAddonUpdateScreen(ProgressScreen):
                 self.execute_error("An internet connection is required to continue\n\nVerify connectivity and try again")
 
             elif not constants.check_free_space(telepath_data=server_obj._telepath_data):
-                self.execute_error("Your primary disk is almost full\n\nFree up space and try again")
+                self.execute_error("Your primary disk is almost full (<15GB)\n\nFree up space and try again")
 
             else: foundry.pre_addon_update()
 

--- a/source/ui/desktop/views/server/manager/backup.py
+++ b/source/ui/desktop/views/server/manager/backup.py
@@ -973,7 +973,7 @@ class ServerCloneProgressScreen(ProgressScreen):
         def before_func(*args):
 
             if not constants.check_free_space(telepath_data=foundry.new_server_info['_telepath_data']):
-                self.execute_error("Your primary disk is almost full\n\nFree up space and try again")
+                self.execute_error("Your primary disk is almost full (<15GB)\n\nFree up space and try again")
 
             else: foundry.pre_server_create()
 

--- a/source/ui/desktop/views/server/manager/settings.py
+++ b/source/ui/desktop/views/server/manager/settings.py
@@ -1130,7 +1130,7 @@ class MigrateServerProgressScreen(ProgressScreen):
                 self.execute_error("An internet connection is required to continue\n\nVerify connectivity and try again")
 
             elif not constants.check_free_space(telepath_data=server_obj._telepath_data):
-                self.execute_error("Your primary disk is almost full\n\nFree up space and try again")
+                self.execute_error("Your primary disk is almost full (<15GB)\n\nFree up space and try again")
 
             else:
                 telepath_data = server_obj._telepath_data
@@ -1233,7 +1233,7 @@ class UpdateModpackProgressScreen(ProgressScreen):
                 self.execute_error("An internet connection is required to continue\n\nVerify connectivity and try again")
 
             elif not constants.check_free_space(telepath_data=server_obj._telepath_data):
-                self.execute_error("Your primary disk is almost full\n\nFree up space and try again")
+                self.execute_error("Your primary disk is almost full (<15GB)\n\nFree up space and try again")
 
             else:
                 telepath_data = server_obj._telepath_data

--- a/source/ui/desktop/views/splash.py
+++ b/source/ui/desktop/views/splash.py
@@ -66,7 +66,7 @@ class MainMenuScreen(MenuBackground):
                 self.show_popup(
                     "warning",
                     "Storage Error",
-                    "auto-mcs has limited functionality from low disk space. Further changes can lead to corruption in your servers.\n\nPlease free up space on your disk to minimize issues",
+                    "auto-mcs has limited functionality from low disk space (<15GB). Further changes can lead to corruption in your servers.\n\nPlease free up space on your disk to minimize issues",
                     None
                 )
             Clock.schedule_once(disk_error, 0.5)
@@ -475,7 +475,7 @@ class UpdateAppProgressScreen(ProgressScreen):
                 self.execute_error("An internet connection is required to continue\n\nVerify connectivity and try again")
 
             elif not constants.check_free_space():
-                self.execute_error("Your primary disk is almost full\n\nFree up space and try again")
+                self.execute_error("Your primary disk is almost full (<15GB)\n\nFree up space and try again")
 
 
         def after_func(*args):

--- a/source/ui/headless/init.py
+++ b/source/ui/headless/init.py
@@ -138,7 +138,7 @@ def manage_server(name: str, action: str):
 
         # Ignore if disk is full
         if not constants.check_free_space():
-            return [("info", "There isn't enough disk space to create a server")], 'fail'
+            return [("info", "There isn't enough disk space to create a server. At least 15 GB required to create a server.")], 'fail'
 
         # Name input validation
         if len(name) <= 25:
@@ -232,7 +232,7 @@ def manage_server(name: str, action: str):
 
         # Ignore if disk is full
         if not constants.check_free_space():
-            return [("info", "There isn't enough disk space to import this server")], 'fail'
+            return [("info", "There isn't enough disk space to import this server (<15GB)")], 'fail'
 
         # Run things and stuff
         foundry.pre_server_create()


### PR DESCRIPTION
I encountered this error:
<img width="1012" height="760" alt="image" src="https://github.com/user-attachments/assets/8f29a3fc-ffc7-4326-a921-92787065da39" />

Assumed it wasn't true as I had just formatted the drive. Didn't find minimum requirements noted anywhere.

This change simply adds `(<15GB)` to wherever the `check_free_space()` function is called.
Preferably this value is stored and reused instead of hard coded. Would be great if it would be changed to return some more information straight from the function like how much was required and how much was found to be free. But I don't have the time right now.

P.S. Seeing how often this function is called and how often the same error message is thrown feels a bit like a code smell.