### PR TITLE
Fixed issue with pyinstaller version 6.10 compatibility

### DIFF
--- a/build-tools/reqs-macos.txt
+++ b/build-tools/reqs-macos.txt
@@ -17,7 +17,7 @@ Pillow==10.3.0
 plyer>=2.1.0
 psutil>=6.0.0
 Pygments==2.16.1
-pyinstaller==6.10
+pyinstaller>=6.10
 pyinstaller-hooks-contrib>=2024.7
 pyparsing==3.0.9
 requests==2.32.4


### PR DESCRIPTION
This addresses issue #236 where older versions of pyinstaller will not work with setuptools >= 70.  See https://github.com/pyinstaller/pyinstaller/issues/8554 for details.