### PR TITLE
Add `libstdc++` to Docker image for Spark Profiler

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG ttyd_binary="https://github.com/macarooni-man/auto-mcs-ttyd/releases/downloa
 COPY auto-mcs-${TARGETARCH} /auto-mcs
 
 RUN apk update && apk upgrade && \
-    apk add --no-cache wget json-c libcrypto3 libssl3 libuv libwebsockets libwebsockets-evlib_uv tmux musl zlib && \
+    apk add --no-cache wget json-c libcrypto3 libssl3 libuv libwebsockets libwebsockets-evlib_uv tmux musl zlib libstdc++ && \
     echo "set -g status off" > ~/.tmux.conf && \
     chmod +x auto-mcs && \
     wget -O /usr/bin/auto-mcs-ttyd "$ttyd_binary" && \


### PR DESCRIPTION
add libstdc++ to add profiling capabilities

Spark mod is usually suggested on Fabric for profiling, one of the requirement is `libstdc++`  so it should be available in the base image

more info: https://spark.lucko.me/docs/misc/Using-async-profiler