### PR TITLE
feat: add DISABLE_AUTH flag in launcher.sh

### DIFF
--- a/docker/launcher.sh
+++ b/docker/launcher.sh
@@ -4,28 +4,31 @@ set -eu
 WEB_PORT="${WEB_PORT:-8080}"
 WEB_USERNAME="${WEB_USERNAME:-}"
 WEB_PASSWORD="${WEB_PASSWORD:-}"
+DISABLE_AUTH="${DISABLE_AUTH:-false}"
 
 CRED_EXAMPLE="  - To configure the environment variable credentials:\n    - WEB_USERNAME='U\$ern4me'\n    - WEB_PASSWORD='P@s\$w0rd'"
 
+if [ "$DISABLE_AUTH" = "true" ]; then
+  AUTH_ARGS=""
+else
+  if [ -z "$WEB_USERNAME" ] || [ -z "$WEB_PASSWORD" ]; then
+    printf "[ERROR] The environment variables 'WEB_USERNAME' and 'WEB_PASSWORD' are required\n\n$CRED_EXAMPLE"
+    exit 64
+  fi
 
-# Basic credentials check
-if [ -z "$WEB_USERNAME" ] || [ -z "$WEB_PASSWORD" ]; then
-  printf "[ERROR] The environment variables 'WEB_USERNAME' and 'WEB_PASSWORD' are required\n\n$CRED_EXAMPLE"
-  exit 64
+  case "${WEB_USERNAME}:${WEB_PASSWORD}" in
+    root:auto-mcs|admin:change-me|*:change-me|*:password|admin:admin|*:admin|'':*|*:'')
+      printf "[ERROR] Default/insecure credentials are not allowed\n\n$CRED_EXAMPLE"
+      exit 64
+      ;;
+  esac
+
+  AUTH_ARGS="-c ${WEB_USERNAME}:${WEB_PASSWORD}"
 fi
 
-case "${WEB_USERNAME}:${WEB_PASSWORD}" in
-  root:auto-mcs|admin:change-me|*:change-me|*:password|admin:admin|*:admin|'':*|*:'')
-    printf "[ERROR] Default/insecure credentials are not allowed\n\n$CRED_EXAMPLE"
-    exit 64
-    ;;
-esac
-
-
-# Launch auto-mcs inside TTYD
 exec /usr/bin/auto-mcs-ttyd \
   -p "$WEB_PORT" \
-  -c "${WEB_USERNAME}:${WEB_PASSWORD}" \
+  $AUTH_ARGS \
   -W \
   -t disableLeaveAlert=true \
   -t titleFixed="auto-mcs (docker)" \


### PR DESCRIPTION
optional flag (bool) `DISABLE_AUTH` in docker command/compose file to disable the builtin ttyd basic auth. still errors and warns user if the variables are not set, the flag must be specifically passed

use case: reverse proxy middleware, custom auth, etc.