### PR TITLE
Fix subnet bans not applying to a running server (#265)

### DIFF
--- a/source/core/server/acl.py
+++ b/source/core/server/acl.py
@@ -2700,7 +2700,7 @@ def _apply_runtime_ip_rule(server_obj, rule_value: str, subnet_list: list, remov
         server_obj.silent_command(f'{verb} {rule_value}{suffix}', log=False)
         return
 
-    # Subnet - defer oversized ranges instead of issuing thousands of commands live
+    # Subnet - defer large ranges instead of issuing thousands of commands live
     if ipaddress.ip_network(rule_value, strict=False).num_addresses > address_limit:
         action = 'unbanned' if remove else 'banned'
         server_obj.send_log(f"Subnet '{rule_value}' is too large and will be {action} on server restart", 'warning')

--- a/source/core/server/acl.py
+++ b/source/core/server/acl.py
@@ -1361,46 +1361,9 @@ def gen_iplist(rule_list: list):
     return final_list
 
 
-# Largest subnet (by total addresses, including network/broadcast) that auto-mcs will apply to a live
-# server one IP at a time. Minecraft can only ban single IPs, so subnets are expanded; larger ranges are
-# deferred to the next restart (where 'banned-ips.json' is regenerated in full) to avoid flooding the
-# console with commands. 256 == a /24, which gen_iplist expands to 254 usable IPs.
-max_live_subnet_addresses = 256
-
-
-# Applies a single ban/whitelist rule to an already-running server. Subnets are expanded into individual
-# 'ban-ip'/'pardon-ip' commands since Minecraft can't ban a CIDR range directly, respecting any
-# whitelisted ('!w') carve-outs in subnet_list. Oversized subnets are skipped with a console warning, and
-# whitelist rules are left to the next restart where 'banned-ips.json' is rebuilt.
-def apply_runtime_ip_rule(server_obj, rule_value: str, subnet_list: list, remove: bool = False, reason: str = None):
-    verb = 'pardon-ip' if remove else 'ban-ip'
-    suffix = f' {reason}' if (reason and not remove) else ''
-
-    # Whitelist carve-outs are resolved when 'banned-ips.json' is rebuilt on restart
-    if "!w" in rule_value:
-        return
-
-    # Single IP - apply directly
-    if "/" not in rule_value:
-        server_obj.silent_command(f'{verb} {rule_value}{suffix}', log=False)
-        return
-
-    # Subnet - defer oversized ranges instead of issuing thousands of commands live
-    if ipaddress.ip_network(rule_value, strict=False).num_addresses > max_live_subnet_addresses:
-        action = 'unban' if remove else 'ban'
-        # ServerObject.send_log surfaces this in the operator's console panel, unlike the module debug log
-        server_obj.send_log(f"Subnet '{rule_value}' is too large to {action} live - restart the server to apply this rule.", 'warning')
-        return
-
-    # Expand the subnet into individual IPs, minus any whitelisted addresses
-    whitelist_rules = [r for r in subnet_list if "!w" in r.rule]
-    for ip in gen_iplist([AclRule(rule=rule_value, acl_group='subnets')] + whitelist_rules):
-        server_obj.silent_command(f'{verb} {ip}{suffix}', log=False)
-
-
 # Specifically for testing/viewing load_acl() objects
 def print_acl(acl_object: AclManager):
-    print(f"# {'='*60}>  {acl_object.server['name']} - ACL  <{'='*60} #\n\n")
+    print(f"# {'='*60}>  {acl_object._server['name']} - ACL  <{'='*60} #\n\n")
     acl_dict = acl_object.rules
     print("Server Information:\n\n" + f"    New Server: {acl_object._new_server}\n" + "    " + str(acl_object.server) + "\n\n")
     if acl_dict['ops']:
@@ -2468,7 +2431,7 @@ def ban_user(server_name: str, rule_list: str or list, remove=False, force_versi
                             if server_name in constants.server_manager.running_servers:
                                 server_obj = constants.server_manager.running_servers[server_name]
                                 if server_obj.running:
-                                    apply_runtime_ip_rule(server_obj, user, subnet_list, remove=True)
+                                    _apply_runtime_ip_rule(server_obj, user, subnet_list, remove=True)
 
                             break
 
@@ -2492,7 +2455,7 @@ def ban_user(server_name: str, rule_list: str or list, remove=False, force_versi
                         if server_name in constants.server_manager.running_servers:
                             server_obj = constants.server_manager.running_servers[server_name]
                             if server_obj.running:
-                                apply_runtime_ip_rule(server_obj, user, subnet_list, reason=reason)
+                                _apply_runtime_ip_rule(server_obj, user, subnet_list, reason=reason)
 
 
         if write_file:
@@ -2720,6 +2683,33 @@ def wl_user(server_name: str, rule_list: str or list, remove=False, force_versio
 
     concat_db()
     return wl_list, new_op_list
+
+
+# Helper to internally apply an IP rule to a running server
+def _apply_runtime_ip_rule(server_obj, rule_value: str, subnet_list: list, remove: bool = False, reason: str = None):
+    address_limit = 256
+    verb = 'pardon-ip' if remove else 'ban-ip'
+    suffix = f' {reason}' if (reason and not remove) else ''
+
+    # Whitelist carve-outs are resolved when 'banned-ips.json' is rebuilt on restart
+    if "!w" in rule_value:
+        return
+
+    # Single IP - apply directly
+    if "/" not in rule_value:
+        server_obj.silent_command(f'{verb} {rule_value}{suffix}', log=False)
+        return
+
+    # Subnet - defer oversized ranges instead of issuing thousands of commands live
+    if ipaddress.ip_network(rule_value, strict=False).num_addresses > address_limit:
+        action = 'unbanned' if remove else 'banned'
+        server_obj.send_log(f"Subnet '{rule_value}' is too large and will be {action} on server restart", 'warning')
+        return
+
+    # Expand the subnet into individual IPs, minus any whitelisted addresses
+    whitelist_rules = [r for r in subnet_list if "!w" in r.rule]
+    for ip in gen_iplist([AclRule(rule=rule_value, acl_group='subnets')] + whitelist_rules):
+        server_obj.silent_command(f'{verb} {ip}{suffix}', log=False)
 
 
 # Converts PlayerScriptObject or list of PlayerScriptObjects to str

--- a/source/core/server/acl.py
+++ b/source/core/server/acl.py
@@ -1361,6 +1361,43 @@ def gen_iplist(rule_list: list):
     return final_list
 
 
+# Largest subnet (by total addresses, including network/broadcast) that auto-mcs will apply to a live
+# server one IP at a time. Minecraft can only ban single IPs, so subnets are expanded; larger ranges are
+# deferred to the next restart (where 'banned-ips.json' is regenerated in full) to avoid flooding the
+# console with commands. 256 == a /24, which gen_iplist expands to 254 usable IPs.
+max_live_subnet_addresses = 256
+
+
+# Applies a single ban/whitelist rule to an already-running server. Subnets are expanded into individual
+# 'ban-ip'/'pardon-ip' commands since Minecraft can't ban a CIDR range directly, respecting any
+# whitelisted ('!w') carve-outs in subnet_list. Oversized subnets are skipped with a console warning, and
+# whitelist rules are left to the next restart where 'banned-ips.json' is rebuilt.
+def apply_runtime_ip_rule(server_obj, rule_value: str, subnet_list: list, remove: bool = False, reason: str = None):
+    verb = 'pardon-ip' if remove else 'ban-ip'
+    suffix = f' {reason}' if (reason and not remove) else ''
+
+    # Whitelist carve-outs are resolved when 'banned-ips.json' is rebuilt on restart
+    if "!w" in rule_value:
+        return
+
+    # Single IP - apply directly
+    if "/" not in rule_value:
+        server_obj.silent_command(f'{verb} {rule_value}{suffix}', log=False)
+        return
+
+    # Subnet - defer oversized ranges instead of issuing thousands of commands live
+    if ipaddress.ip_network(rule_value, strict=False).num_addresses > max_live_subnet_addresses:
+        action = 'unban' if remove else 'ban'
+        # ServerObject.send_log surfaces this in the operator's console panel, unlike the module debug log
+        server_obj.send_log(f"Subnet '{rule_value}' is too large to {action} live - restart the server to apply this rule.", 'warning')
+        return
+
+    # Expand the subnet into individual IPs, minus any whitelisted addresses
+    whitelist_rules = [r for r in subnet_list if "!w" in r.rule]
+    for ip in gen_iplist([AclRule(rule=rule_value, acl_group='subnets')] + whitelist_rules):
+        server_obj.silent_command(f'{verb} {ip}{suffix}', log=False)
+
+
 # Specifically for testing/viewing load_acl() objects
 def print_acl(acl_object: AclManager):
     print(f"# {'='*60}>  {acl_object.server['name']} - ACL  <{'='*60} #\n\n")
@@ -2427,11 +2464,11 @@ def ban_user(server_name: str, rule_list: str or list, remove=False, force_versi
                             subnet_list.pop(x)
                             ip_list.pop(x)
 
-                            # If server is running, check if player is online and run a command
+                            # If server is running, apply the rule to it dynamically
                             if server_name in constants.server_manager.running_servers:
                                 server_obj = constants.server_manager.running_servers[server_name]
                                 if server_obj.running:
-                                    server_obj.silent_command(f'pardon-ip {user}', log=False)
+                                    apply_runtime_ip_rule(server_obj, user, subnet_list, remove=True)
 
                             break
 
@@ -2451,11 +2488,11 @@ def ban_user(server_name: str, rule_list: str or list, remove=False, force_versi
                         subnet_list.append(acl_object)
                         ip_list.append(user.lower())
 
-                        # If server is running, check if player is online and run a command
+                        # If server is running, apply the rule to it dynamically
                         if server_name in constants.server_manager.running_servers:
                             server_obj = constants.server_manager.running_servers[server_name]
                             if server_obj.running:
-                                server_obj.silent_command(f'ban-ip {user}{reason}', log=False)
+                                apply_runtime_ip_rule(server_obj, user, subnet_list, reason=reason)
 
 
         if write_file:


### PR DESCRIPTION
Closes #265.

## Problem
Adding a CIDR subnet ban (e.g. `192.168.0.0/24`) to an **already-running** server sent the raw CIDR straight to Minecraft's `ban-ip`, which only accepts single IPs — so the server threw an error in the console (see the issue screenshot). The same happened with `pardon-ip` when removing a subnet rule.

## Fix
Subnet rules applied at runtime are now expanded into individual `ban-ip`/`pardon-ip` commands via the existing `gen_iplist` helper — the same expansion already used to build `banned-ips.json` on startup — so the live server state matches the on-disk rules. Whitelisted (`!w`) carve-outs inside the range are respected.

To avoid flooding a running server with thousands of commands, subnets larger than a `/24` (256 addresses) are not applied live; instead a warning is shown in the console asking the operator to restart, where the full rule is enforced from `banned-ips.json` as before. The file-write path is unchanged.

Also fixes an adjacent formatting bug on the same line: `ban-ip {user}{reason}` was missing a space and appended `None` when no reason was given (e.g. `ban-ip 1.2.3.4None`).

All of this lives in a small `apply_runtime_ip_rule()` helper in `source/core/server/acl.py`; the two runtime call sites in `ban_user` now delegate to it.

## Before / After
On a running server — **Access Control → Bans → Add Rule → `192.168.0.0/24`**:

**Before:** `ban-ip 192.168.0.0/24` → console error (invalid IP argument).

**After:** 254 individual bans, accepted by the server:
```
Banned IP 192.168.0.1: Banned by an operator.
...
Banned IP 192.168.0.254: Banned by an operator.
```

Adding an oversized range `10.0.0.0/16`:
```
Subnet '10.0.0.0/16' is too large to ban live - restart the server to apply this rule.
```
No commands are flooded; the full range still persists to `banned-ips.json` and applies on restart.

## Testing
Verified on **Linux** (GUI, Vanilla server):
- Adding `/24` to a running server produced exactly 254 accepted `ban-ip` commands, no console error.
- Adding `/16` produced zero live commands (no flood) plus the restart warning, while `banned-ips.json` still contained the full expansion (254 + 65534 entries).
- Single-IP bans and the `reason` formatting fix confirmed.

Not yet tested on Windows/macOS — would appreciate help covering those.
