### PR TITLE
Update back-up config in place instead of repacking (#129)

### DIFF
--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -2259,13 +2259,35 @@ def generate_splash(crash=False):
 
 
 # Helper to safely load a ConfigParser object
-def load_config(path: str = None) -> ConfigParser:
+def load_config(path: str = None, data: bytes = None) -> ConfigParser:
+    encodings = (
+        ("utf-8", "strict"),
+        ("cp1252", "strict"),
+        ("latin-1", "strict"),
+        ("utf-8", "replace"),
+    )
+
     config = ConfigParser(allow_no_value=True, comment_prefixes=';', interpolation=None)
     config.optionxform = str
 
-    if path:
-        try:
-            for enc, err in (("utf-8", "strict"), ("utf-8", "replace"), ("cp1252", "strict"), ("latin-1", "strict")):
+    if path is not None and data is not None:
+        raise ValueError('Only pass <path> or <data>, not both')
+
+    try:
+
+        # Read passed data as bytes of a valid ConfigParser string
+        if data is not None:
+            for enc, err in encodings:
+                try:
+                    config.read_string(data.decode(enc, errors=err))
+                    break
+                except UnicodeDecodeError:
+                    config.clear()
+                    continue
+
+        # Read passed file path to a valid ConfigParser .ini
+        elif path:
+            for enc, err in encodings:
                 try:
                     with open(path, "r", encoding=enc, errors=err) as f:
                         config.read_file(f, source=path)
@@ -2273,8 +2295,9 @@ def load_config(path: str = None) -> ConfigParser:
                 except UnicodeDecodeError:
                     config.clear()
                     continue
-        except FileNotFoundError:
-            pass
+
+    except FileNotFoundError:
+        pass
 
     return config
 

--- a/source/core/server/backup.py
+++ b/source/core/server/backup.py
@@ -1,4 +1,3 @@
-from configparser import ConfigParser
 from datetime import datetime as dt
 from functools import reduce
 from glob import glob
@@ -501,39 +500,29 @@ def restore_server(name: str, backup_name: str, backup_stats=None) -> dict[str, 
             send_log('restore_server', f"error restoring '{name}' to '{backup_name}': {constants.format_traceback(e)}", 'error')
 
 
-# Updates the auto-mcs.ini inside a back-up archive in place using Python's tarfile, copying every other
-# member across untouched instead of extracting and repacking the whole archive. This is far faster for
-# large back-ups and, unlike the 'tar' CLI, behaves the same on every OS (the CLI can't edit in place on
-# Windows). 'mutate(config)' receives the loaded ConfigParser and returns True if it changed anything.
-# Returns True if the archive was updated.
-def update_backup_config(amb_path: str, mutate) -> bool:
+# Updates the auto-mcs.ini inside a back-up archive in place using Python's tarfile
+def update_backup_config(server_name: str, backup_path: str, section: str, option: str, new_value) -> bool:
     ini_names = ('auto-mcs.ini', '.auto-mcs.ini')
-    tmp_path = amb_path + '.tmp'
+    tmp_path = backup_path + '.tmp'
     updated = False
 
     try:
-        with tarfile.open(amb_path, 'r') as src, tarfile.open(tmp_path, 'w') as dst:
+        with tarfile.open(backup_path, 'r') as src, tarfile.open(tmp_path, 'w') as dst:
             for member in src.getmembers():
 
                 # Rewrite the config member; copy everything else verbatim
                 if member.isfile() and os.path.basename(member.name) in ini_names:
                     raw = src.extractfile(member).read()
+                    config = load_config(data=raw)
 
-                    # Decode like load_config() does, so non-UTF-8 inis aren't mangled on rewrite
-                    text = None
-                    for enc in ('utf-8', 'cp1252', 'latin-1'):
-                        try:
-                            text = raw.decode(enc)
-                            break
-                        except UnicodeDecodeError:
+                    if config.sections():
+
+                        # Don't do anything if this likely isn't the same server
+                        if config.get('general', 'serverName', fallback=None) != server_name:
+                            dst.addfile(member, io.BytesIO(raw))
                             continue
-                    if text is None:
-                        text = raw.decode('utf-8', errors='replace')
 
-                    config = load_config()
-                    config.read_string(text)
-
-                    if config.sections() and mutate(config):
+                        config.set(section, option, new_value)
                         buffer = io.StringIO()
                         config.write(buffer)
                         data = buffer.getvalue().encode('utf-8')
@@ -543,6 +532,7 @@ def update_backup_config(amb_path: str, mutate) -> bool:
                         info.size = len(data)
                         dst.addfile(info, io.BytesIO(data))
                         updated = True
+
                     else:
                         dst.addfile(member, io.BytesIO(raw))
 
@@ -552,7 +542,8 @@ def update_backup_config(amb_path: str, mutate) -> bool:
                 else:
                     dst.addfile(member)
 
-        os.replace(tmp_path, amb_path)
+        if updated: os.replace(tmp_path, backup_path)
+        else:       os.remove(tmp_path)
         return updated
 
     except Exception:
@@ -587,16 +578,10 @@ def set_backup_directory(name: str, new_dir: str, new_amount: str):
                 constants.folder_check(new_dir)
                 if os.access(new_dir, os.W_OK):
 
-                    # Update each back-up's bkupDir in place, then move the file to the new directory
-                    def mutate(config):
-                        if config.get('general', 'serverName', fallback=None) == name:
-                            config.set('bkup', 'bkupDir', new_dir)
-                            return True
-                        return False
-
+                    # Update each back-up's bkupDir in embedded config, then move the file to the new directory
                     for file in glob(os.path.join(current_dir, f"{name}__*")):
                         try:
-                            if update_backup_config(file, mutate):
+                            if update_backup_config(name, file, 'bkup', 'bkupDir', new_dir):
                                 shutil.move(file, os.path.join(new_dir, os.path.basename(file)))
                         except Exception as e:
                             send_log('set_backup_directory', f"error migrating back-up '{file}': {constants.format_traceback(e)}", 'error')
@@ -657,14 +642,8 @@ def rename_backup(file: str, new_name: str):
     send_log('rename_backup', f"renaming back-up '{file}' to '{new_name}'...", 'info')
 
     try:
-        # Only the serverName in auto-mcs.ini changes, so update it in place instead of repacking
-        def mutate(config):
-            if config.get('general', 'serverName', fallback=None) == name:
-                config.set('general', 'serverName', new_name)
-                return True
-            return False
-
-        if update_backup_config(file, mutate):
+        # Update serverName inside embedded .ini
+        if update_backup_config(name, file, 'general', 'serverName', new_name):
             new_path = os.path.join(current_dir, os.path.basename(file).replace(f"{name}__", f"{new_name}__"))
             os.rename(file, new_path)
 

--- a/source/core/server/backup.py
+++ b/source/core/server/backup.py
@@ -572,7 +572,7 @@ def set_backup_directory(name: str, new_dir: str, new_amount: str):
         # Don't allow any folders inside of app path unless it's the Backups directory
         send_log('set_backup_directory', f"changing back-up directory for '{name}' to '{new_dir}'...", 'info')
         try:
-            if ((paths.app_folder not in new_dir) or (new_dir == paths.backups)) and (new_dir != current_dir):
+            if ((paths.app_folder not in new_dir) or (paths.backups in new_dir)) and (new_dir != current_dir):
 
                 # Check if folder exists and is writeable
                 constants.folder_check(new_dir)

--- a/source/core/server/backup.py
+++ b/source/core/server/backup.py
@@ -2,8 +2,12 @@ from configparser import ConfigParser
 from datetime import datetime as dt
 from functools import reduce
 from glob import glob
+import tarfile
+import shutil
+import copy
 import time
 import os
+import io
 
 from source.core.translator import translate
 from source.core.constants import paths
@@ -497,6 +501,66 @@ def restore_server(name: str, backup_name: str, backup_stats=None) -> dict[str, 
             send_log('restore_server', f"error restoring '{name}' to '{backup_name}': {constants.format_traceback(e)}", 'error')
 
 
+# Updates the auto-mcs.ini inside a back-up archive in place using Python's tarfile, copying every other
+# member across untouched instead of extracting and repacking the whole archive. This is far faster for
+# large back-ups and, unlike the 'tar' CLI, behaves the same on every OS (the CLI can't edit in place on
+# Windows). 'mutate(config)' receives the loaded ConfigParser and returns True if it changed anything.
+# Returns True if the archive was updated.
+def update_backup_config(amb_path: str, mutate) -> bool:
+    ini_names = ('auto-mcs.ini', '.auto-mcs.ini')
+    tmp_path = amb_path + '.tmp'
+    updated = False
+
+    try:
+        with tarfile.open(amb_path, 'r') as src, tarfile.open(tmp_path, 'w') as dst:
+            for member in src.getmembers():
+
+                # Rewrite the config member; copy everything else verbatim
+                if member.isfile() and os.path.basename(member.name) in ini_names:
+                    raw = src.extractfile(member).read()
+
+                    # Decode like load_config() does, so non-UTF-8 inis aren't mangled on rewrite
+                    text = None
+                    for enc in ('utf-8', 'cp1252', 'latin-1'):
+                        try:
+                            text = raw.decode(enc)
+                            break
+                        except UnicodeDecodeError:
+                            continue
+                    if text is None:
+                        text = raw.decode('utf-8', errors='replace')
+
+                    config = load_config()
+                    config.read_string(text)
+
+                    if config.sections() and mutate(config):
+                        buffer = io.StringIO()
+                        config.write(buffer)
+                        data = buffer.getvalue().encode('utf-8')
+
+                        # Copy the TarInfo so we don't mutate the source archive's member
+                        info = copy.copy(member)
+                        info.size = len(data)
+                        dst.addfile(info, io.BytesIO(data))
+                        updated = True
+                    else:
+                        dst.addfile(member, io.BytesIO(raw))
+
+                # Regular files stream straight across, links/dirs carry no data
+                elif member.isfile():
+                    dst.addfile(member, src.extractfile(member))
+                else:
+                    dst.addfile(member)
+
+        os.replace(tmp_path, amb_path)
+        return updated
+
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
+
+
 # Migrate backup directory and backups
 def set_backup_directory(name: str, new_dir: str, new_amount: str):
 
@@ -523,42 +587,23 @@ def set_backup_directory(name: str, new_dir: str, new_amount: str):
                 constants.folder_check(new_dir)
                 if os.access(new_dir, os.W_OK):
 
-                    # Migrate backup directory and backups
-                    extract_folder = os.path.join(paths.temp, 'bkup_tmp')
+                    # Update each back-up's bkupDir in place, then move the file to the new directory
+                    def mutate(config):
+                        if config.get('general', 'serverName', fallback=None) == name:
+                            config.set('bkup', 'bkupDir', new_dir)
+                            return True
+                        return False
 
-                    # Iterate over each back-up that could be a match in current back-up directory
                     for file in glob(os.path.join(current_dir, f"{name}__*")):
-                        constants.folder_check(extract_folder)
-                        os.chdir(extract_folder)
-
-                        # Extract auto-mcs.ini from each match and check the server name just to be sure
-                        constants.run_proc(f'tar -xvf "{file}"')  # *auto-mcs.ini
-
-                        configs = glob(os.path.join(extract_folder, 'auto-mcs.ini'))
-                        configs.extend(glob(os.path.join(extract_folder, '.auto-mcs.ini')))
-                        for cfg in configs:
-                            config = load_config(cfg)
-                            if config.sections():
-                                if config.get('general', 'serverName') == name:
-
-                                    # Update bkupDir with new_dir in the back-ups' auto-mcs.ini
-                                    config.set('bkup', 'bkupDir', new_dir)
-                                    with open(cfg, 'w') as f:
-                                        config.write(f)
-
-                                    constants.run_proc(f'tar -cvf \"{os.path.join(new_dir, os.path.basename(file))}\" {"*" if constants.os_name == "windows" else "* .??*"}')
-
-                                    # constants.copy(file, new_dir)
-                                    os.remove(file)
-                                    break
-
-                        os.chdir(paths.temp)
-                        constants.safe_delete(extract_folder)
+                        try:
+                            if update_backup_config(file, mutate):
+                                shutil.move(file, os.path.join(new_dir, os.path.basename(file)))
+                        except Exception as e:
+                            send_log('set_backup_directory', f"error migrating back-up '{file}': {constants.format_traceback(e)}", 'error')
 
 
                     # Update bkupDir
                     os.chdir(cwd)
-                    constants.safe_delete(paths.temp)
                     config_file.set('bkup', 'bkupDir', new_dir)
                     config_file.set('bkup', 'bkupMax', str(new_amount))
                     manager.server_config(name, config_file)
@@ -596,8 +641,6 @@ def rename_backups(name: str, new_name: str):
             for file in file_list:
                 if not rename_backup(file, new_name): failure = True
 
-            # Cleanup
-            constants.safe_delete(paths.temp)
             set_lock(name, False)
 
             if failure: send_log('rename_backups', f"there were errors while renaming all back-ups for '{name}' to '{new_name}'", 'error')
@@ -608,48 +651,27 @@ def rename_backups(name: str, new_name: str):
     set_lock(name, False)
     return None
 def rename_backup(file: str, new_name: str):
-    cwd = constants.get_cwd()
     current_dir = os.path.dirname(file)
     name = os.path.basename(file).split('__')[0].strip()
-
-    # Migrate backup directory and backups
-    extract_folder = os.path.join(paths.temp, 'bkup_tmp')
     new_path = None
     send_log('rename_backup', f"renaming back-up '{file}' to '{new_name}'...", 'info')
 
     try:
-        constants.folder_check(extract_folder)
-        os.chdir(extract_folder)
+        # Only the serverName in auto-mcs.ini changes, so update it in place instead of repacking
+        def mutate(config):
+            if config.get('general', 'serverName', fallback=None) == name:
+                config.set('general', 'serverName', new_name)
+                return True
+            return False
 
-        # Extract auto-mcs.ini from each match and check the server name just to be sure
-        constants.run_proc(f'tar -xvf "{file}"')  # *auto-mcs.ini
-
-        config_files = []
-        config_files.extend(glob(os.path.join(extract_folder, 'auto-mcs.ini')))
-        config_files.extend(glob(os.path.join(extract_folder, '.auto-mcs.ini')))
-
-        for cfg in config_files:
-            config = load_config(cfg)
-            if config.sections():
-                if config.get('general', 'serverName') == name:
-
-                    # Update bkupDir with new_dir in the back-ups' auto-mcs.ini
-                    config.set('general', 'serverName', new_name)
-                    with open(cfg, 'w') as f:
-                        config.write(f)
-
-                    os.remove(file)
-                    new_path = os.path.join(current_dir, os.path.basename(file).replace(f"{name}__", f"{new_name}__"))
-                    constants.run_proc(f'tar -cvf \"{new_path}\" {"*" if constants.os_name == "windows" else "* .??*"}')
-                    break
+        if update_backup_config(file, mutate):
+            new_path = os.path.join(current_dir, os.path.basename(file).replace(f"{name}__", f"{new_name}__"))
+            os.rename(file, new_path)
 
     except Exception as e:
         send_log('rename_backup', f"error renaming back-up '{file}' to '{new_name}': {constants.format_traceback(e)}", 'error')
 
     if new_path: send_log('rename_backup', f"successfully renamed back-up '{file}' to '{new_name}'", 'info')
-
-    os.chdir(cwd)
-    constants.safe_delete(extract_folder)
     return new_path
 
 


### PR DESCRIPTION
Closes #129.

## Problem
Renaming or moving a back-up only needs to change one small file — `auto-mcs.ini` — inside the `.amb` archive. But the code extracted the **entire** archive to disk with `tar -xvf` and repacked it with `tar -cvf`. For multi-GB back-ups that's slow, and the `tar` CLI can't edit an archive in place on Windows (which is why this couldn't be done before).

## Fix
A new `update_backup_config(amb_path, mutate)` helper rewrites just the `auto-mcs.ini` member using Python's `tarfile`, streaming every other member straight across into a fresh archive untouched (no disk round-trip for the bulk data), then atomically `os.replace`-ing it over the original. It's pure Python, so it behaves the same on every OS. `mutate(config)` receives the loaded `ConfigParser` and returns whether it changed anything.

- `rename_backup()` now updates `serverName` in place, then `os.rename`s the file.
- `set_backup_directory()` now updates `bkupDir` in place, then `shutil.move`s the file to the new directory.
- `rename_backups()` is unchanged (it delegates to `rename_backup`).

The config-reading uses the project's own `load_config` parser (case-preserving) with the same `utf-8 → cp1252 → latin-1` decode fallback, so camelCase keys and non-ASCII server names survive the rewrite.

## Testing
Verified on **Linux** (offline, exercising the real helper):
- Renamed a real `.amb`: archive stays valid, the member set is unchanged, every non-`auto-mcs.ini` member is byte- and metadata-identical, `serverName` is updated, and the camelCase keys (`bkupDir`, `serverVersion`, `bkupMax`, …) are preserved (not lower-cased).
- Synthetic archive with nested directories and a symlink: directories and the symlink (with correct `linkname`) are preserved.
- A `.amb` whose `auto-mcs.ini` is CP1252-encoded (e.g. a non-ASCII server name): rewritten to UTF-8 with no `�` corruption.

Not yet tested on Windows/macOS.
