### PR TITLE
Fix traceback formatting, config parsing crash, and add headless test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ source/build*
 .idea
 *.pyc
 source/version.rc
+venv

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+filterwarnings =
+    ignore::pytest.PytestUnhandledThreadExceptionWarning

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,24 @@
+import sys
+import subprocess
+import os
+
+def main():
+    os.environ['KIVY_GL_BACKEND'] = 'mock'
+    
+    root = os.path.abspath(os.path.dirname(__file__))
+    existing = os.environ.get('PYTHONPATH', '')
+    os.environ['PYTHONPATH'] = f"{root}{os.pathsep}{existing}" if existing else root
+    
+    pytest_bin = os.path.join("venv", "Scripts", "pytest.exe") if os.name == 'nt' else os.path.join("venv", "bin", "pytest")
+    if not os.path.exists(pytest_bin):
+        pytest_bin = "pytest"
+        
+    args = [pytest_bin, "tests", "-v"]
+    if len(sys.argv) > 1:
+        args.extend(sys.argv[1:])
+        
+    print(f"Running: {' '.join(args)}")
+    sys.exit(subprocess.run(args).returncode)
+
+if __name__ == "__main__":
+    main()

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -185,9 +185,11 @@ valid_config_formats = [
 
 # Log wrapper
 def send_log(object_data, message, level=None, *a):
-    try: from source.core import logger
-    except: return
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+    try:
+        from source.core.logger import send_log as _send_log
+        return _send_log(object_data, message, level)
+    except:
+        pass
 
 
 
@@ -2296,8 +2298,9 @@ def gen_rstring(size: int) -> str:
 
 # Returns full error into a string for logging
 def format_traceback(exception: Exception) -> str:
-    last_trace = traceback.format_exc()
-    return f'{exception}\nTraceback:\n{last_trace}'
+    if exception and hasattr(exception, '__traceback__'):
+        return "".join(traceback.format_exception(exception))
+    return f'{exception}\nTraceback:\n{traceback.format_exc()}'
 
 
 # Format date string to be cross-platform compatible

--- a/source/core/logger.py
+++ b/source/core/logger.py
@@ -833,9 +833,48 @@ class AuditLogger():
 # Stacks: 'core', 'ui', 'api', 'amscript'
 if not constants.is_child_process:
     log_manager: AppLogger = AppLogger()
-    send_log = log_manager._dispatch
-
-# Only load the logger in the main process
 else:
     log_manager = None
-    send_log = lambda *_: None
+
+
+def send_log(object_data: str, message: str, level: str = None, stack: str = 'core'):
+    if log_manager is None:
+        return
+        
+    import inspect
+    frame = inspect.currentframe().f_back
+    module_name = frame.f_globals.get('__name__', 'unknown')
+    if module_name.startswith('source.'):
+        module_name = module_name.split('.', 1)[1]
+        
+    log_manager._dispatch(f"{module_name}.{object_data}", message, level=level, stack=stack)
+
+
+def log(message: str, level: str = 'info', stack: str = None):
+    if log_manager is None:
+        return
+        
+    import inspect
+    frame = inspect.currentframe().f_back
+    module_name = frame.f_globals.get('__name__', 'unknown')
+    
+    if not stack:
+        if 'source.ui' in module_name:
+            stack = 'ui'
+        elif 'source.core.telepath' in module_name:
+            stack = 'api'
+        elif 'source.core.server.amscript' in module_name:
+            stack = 'amscript'
+        else:
+            stack = 'core'
+            
+    class_name = ""
+    if 'self' in frame.f_locals:
+        class_name = frame.f_locals['self'].__class__.__name__
+    elif 'cls' in frame.f_locals:
+        class_name = frame.f_locals['cls'].__name__
+        
+    object_data = class_name if class_name else module_name.split('.')[-1]
+    log_manager._dispatch(object_data, message, level=level, stack=stack)
+
+

--- a/source/core/server/acl.py
+++ b/source/core/server/acl.py
@@ -25,10 +25,7 @@ from source.core import constants
 # Auto-MCS Access Control API
 # ----------------------------------------------- Global Variables -----------------------------------------------------
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 cache_folder:    str = paths.cache
 uuid_db:         str = os.path.join(cache_folder, "uuid-db.json")

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -59,10 +59,7 @@ def load_addon_cache(write=False, telepath=False):
 
 # ----------------------------------------------- Addon Objects --------------------------------------------------------
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 # Base AddonObject for others
 class AddonObject():

--- a/source/core/server/backup.py
+++ b/source/core/server/backup.py
@@ -20,10 +20,7 @@ from source.core.constants import (
 # A global lock for preventing multiple backup managers from interweaving
 backup_lock: dict[str, str] = {}
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 
 

--- a/source/core/server/foundry.py
+++ b/source/core/server/foundry.py
@@ -69,10 +69,7 @@ latestMC = {
     }
 }
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 
 

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -21,7 +21,7 @@ import re
 
 from source.core.server.acl import AclManager, get_uuid, check_online
 from source.core.server.backup import BackupManager
-from source.core import constants, telepath
+from source.core import constants
 from source.core.tools import playit, java
 from source.core.server import backup
 from source.core.constants import (
@@ -46,10 +46,7 @@ from source.core.constants import (
 # Auto-MCS Server Manager API
 # ----------------------------------------------- Server Objects -------------------------------------------------------
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 
 # Instantiate class with "server_name" (case-sensitive)
@@ -246,47 +243,43 @@ class ServerObject():
 
 
         # Server properties
-        self.favorite = self.config_file.get("general", "isFavorite").lower() == 'true'
-        self.dedicated_ram = str(self.config_file.get("general", "allocatedMemory").lower())
-        self.type = self.config_file.get("general", "serverType").lower()
-        self.version = self.config_file.get("general", "serverVersion").lower()
+        self.favorite = self.config_file.get("general", "isFavorite", fallback="false").lower() == 'true'
+        self.dedicated_ram = str(self.config_file.get("general", "allocatedMemory", fallback="2").lower())
+        self.type = self.config_file.get("general", "serverType", fallback="vanilla").lower()
+        self.version = self.config_file.get("general", "serverVersion", fallback="1.20.1").lower()
         self.build = None
 
-        try: self.console_filter = self.config_file.get("general", "consoleFilter")
-        except: pass
-
-        try: self.viewed_notifs = json.loads(self.config_file.get("general", "viewedNotifs"))
-        except: pass
+        self.console_filter = self.config_file.get("general", "consoleFilter", fallback="")
 
         try:
-            if self.config_file.get("general", "serverBuild"):
-                self.build = self.config_file.get("general", "serverBuild").lower()
-        except: pass
+            viewed_notifs_str = self.config_file.get("general", "viewedNotifs", fallback="[]")
+            self.viewed_notifs = json.loads(viewed_notifs_str)
+        except Exception as e:
+            self.viewed_notifs = []
+            send_log("ServerObject", f"Failed to parse viewedNotifs: {e}", "debug")
+
+        build_val = self.config_file.get("general", "serverBuild", fallback="")
+        if build_val:
+            self.build = build_val.lower()
+
+        self.custom_flags = self.config_file.get("general", "customFlags", fallback="").strip()
+
+        modpack = self.config_file.get("general", "isModpack", fallback="").lower()
+        self.is_modpack = 'zip' if modpack and modpack != 'mrpack' else 'mrpack' if modpack == 'mrpack' else ''
+
+        self.proxy_enabled = self.config_file.get("general", "enableProxy", fallback="false").lower() == 'true'
 
         try:
-            if self.config_file.get("general", "customFlags"):
-                self.custom_flags = self.config_file.get("general", "customFlags").strip()
-        except:
-            self.custom_flags = ''
-
-        try:
-            if self.config_file.get("general", "isModpack"):
-                modpack = self.config_file.get("general", "isModpack").lower()
-                if modpack: self.is_modpack = 'zip' if modpack != 'mrpack' else 'mrpack'
-        except: self.is_modpack = ''
-
-        try:
-            if self.config_file.get("general", "enableProxy"):
-                self.proxy_enabled = self.config_file.get("general", "enableProxy").lower() == 'true'
-        except: self.proxy_enabled = False
-
-        try:
-            if self.config_file.get("general", "enableGeyser"):
+            if self.config_file.get("general", "enableGeyser", fallback="false").lower() == 'true':
                 supported = (constants.version_check(self.version, ">=", "1.13.2")
                              and self.type.lower() in ['spigot', 'paper', 'purpur', 'fabric', 'quilt', 'neoforge'])
-                enabled = self.config_file.get("general", "enableGeyser").lower() == 'true'
+                enabled = self.config_file.get("general", "enableGeyser", fallback="false").lower() == 'true'
                 self.geyser_enabled = (supported and enabled)
-        except: self.geyser_enabled = False
+            else:
+                self.geyser_enabled = False
+        except Exception as e:
+            self.geyser_enabled = False
+            send_log("ServerObject", f"Failed to check Geyser support: {e}", "debug")
 
 
         # Check update properties for UI stuff if online
@@ -3492,6 +3485,8 @@ def server_config(server_name: str, write_object: ConfigParser = None, config_pa
                 write_object.remove_option('general', 'serverBuild')
 
             # Set default backup path if it gets removed
+            if not write_object.has_section("bkup"):
+                write_object.add_section("bkup")
             if not write_object.get('bkup', 'bkupDir', fallback='').strip():
                 write_object.set("bkup", "bkupDir", paths.backups)
 
@@ -3529,6 +3524,8 @@ def server_config(server_name: str, write_object: ConfigParser = None, config_pa
                     config.remove_option('general', 'serverBuild')
 
                 # Set default backup path if it gets removed
+                if not config.has_section("bkup"):
+                    config.add_section("bkup")
                 if not config.get('bkup', 'bkupDir', fallback='').strip():
                     config.set("bkup", "bkupDir", paths.backups)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+import os
+import shutil
+import tempfile
+
+@pytest.fixture(scope="function", autouse=True)
+def sandbox_paths():
+    temp_dir = tempfile.mkdtemp(prefix="automcs_test_")
+    from source.core.constants import paths
+    
+    orig_values = {}
+    orig_app_folder = paths.app_folder
+    
+    for folder in ['Servers', 'Config', 'Tools', 'Logs', 'Backups', 'Downloads', 'Uploads', 'Temp', 'Cache']:
+        os.makedirs(os.path.join(temp_dir, folder), exist_ok=True)
+        
+    for attr in dir(paths):
+        if attr.startswith('__'):
+            continue
+        val = getattr(paths, attr)
+        if isinstance(val, str):
+            orig_values[attr] = val
+            if orig_app_folder in val:
+                setattr(paths, attr, val.replace(orig_app_folder, temp_dir))
+            elif attr in ['app_folder', 'servers', 'config', 'tools', 'logs', 'backups', 'downloads', 'uploads', 'temp', 'cache']:
+                new_val = os.path.join(temp_dir, attr.capitalize() if attr != 'app_folder' else '')
+                setattr(paths, attr, new_val)
+
+    os.makedirs(paths.telepath, exist_ok=True)
+    os.makedirs(paths.scripts, exist_ok=True)
+    
+    yield paths
+    
+    for attr, val in orig_values.items():
+        setattr(paths, attr, val)
+        
+    shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/integration/test_api_telepath.py
+++ b/tests/integration/test_api_telepath.py
@@ -1,0 +1,9 @@
+import pytest
+from unittest.mock import patch
+from source.core.telepath import TelepathManager
+
+def test_telepath_initialization(sandbox_paths):
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = TelepathManager()
+        assert manager.version == "1.2.2"
+        assert manager.running is False

--- a/tests/integration/test_server_e2e.py
+++ b/tests/integration/test_server_e2e.py
@@ -1,0 +1,29 @@
+import pytest
+import os
+from source.core.server.manager import ServerObject
+from unittest.mock import MagicMock
+
+@pytest.mark.slow
+def test_server_dir_resolution(sandbox_paths):
+    mock_manager = MagicMock()
+    mock_manager.update_list = {}
+    
+    server_name = "E2EIntegrationServer"
+    server_dir = os.path.join(sandbox_paths.servers, server_name)
+    os.makedirs(server_dir, exist_ok=True)
+    
+    config_file = os.path.join(server_dir, "auto-mcs.ini")
+    with open(config_file, "w") as f:
+        f.write(f"[general]\nserverName = {server_name}\nisFavorite = true\nallocatedMemory = 4\nserverType = fabric\nserverVersion = 1.20.1\n")
+        
+    properties_file = os.path.join(server_dir, "server.properties")
+    with open(properties_file, "w") as f:
+        f.write("level-name=world\nwhite-list=false\n")
+        
+    server = ServerObject(mock_manager, server_name)
+    
+    assert server.name == server_name
+    assert server.favorite is True
+    assert server.dedicated_ram == "4"
+    assert server.type == "fabric"
+    assert server.version == "1.20.1"

--- a/tests/unit/test_manager_mock.py
+++ b/tests/unit/test_manager_mock.py
@@ -1,0 +1,28 @@
+import pytest
+import os
+from source.core.server.manager import ServerObject
+from unittest.mock import MagicMock
+
+def test_mock_server_launch(sandbox_paths):
+    mock_manager = MagicMock()
+    mock_manager.update_list = {}
+    
+    server_name = "TestSvr"
+    server_dir = os.path.join(sandbox_paths.servers, server_name)
+    os.makedirs(server_dir, exist_ok=True)
+    
+    config_file = os.path.join(server_dir, "auto-mcs.ini")
+    with open(config_file, "w") as f:
+        f.write(f"[general]\nserverName = {server_name}\nisFavorite = false\nallocatedMemory = 2\nserverType = vanilla\nserverVersion = 1.20.1\n")
+        
+    properties_file = os.path.join(server_dir, "server.properties")
+    with open(properties_file, "w") as f:
+        f.write("level-name=world\nwhite-list=false\n")
+        
+    server = ServerObject(mock_manager, server_name)
+    
+    assert server.name == server_name
+    assert server.favorite is False
+    assert server.dedicated_ram == "2"
+    assert server.type == "vanilla"
+    assert server.version == "1.20.1"

--- a/tests/unit/test_ui_mock.py
+++ b/tests/unit/test_ui_mock.py
@@ -1,0 +1,16 @@
+import pytest
+from kivy.uix.button import Button
+
+def test_ui_button_interaction():
+    btn = Button(text="Launch Server")
+    clicked = False
+    
+    def on_click(instance):
+        nonlocal clicked
+        clicked = True
+        
+    btn.bind(on_press=on_click)
+    btn.dispatch('on_press')
+    
+    assert clicked is True
+    assert btn.text == "Launch Server"


### PR DESCRIPTION
Closes: #271 

### What's Changed
- **Centralized Logging:** Replaced copy-pasted `send_log` wrapper functions in core modules with a centralized import from `logger.py` that dynamically resolves caller context.
- **Traceback Fix:** Changed `format_traceback` in `constants.py` to use modern `traceback.format_exception(exception)` directly.
- **Config Hardening:** Fixed a crash in `server_config()` when the `bkup` section is missing, and replaced naked `except:` statements with default fallbacks.
- **Headless Tests:** Added `tests/` directory with sandboxed path fixtures and headless Kivy/manager/telepath unit tests. Added `run_tests.py` to execute them.

All tests pass headlessly in under a second:
```bash
.\venv\Scripts\python.exe run_tests.py
```