### PR TITLE
Fix Telepath Port Collisions and Cloned Session Overwrites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ source/build*
 .idea
 *.pyc
 source/version.rc
+venv

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+filterwarnings =
+    ignore::pytest.PytestUnhandledThreadExceptionWarning

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,24 @@
+import sys
+import subprocess
+import os
+
+def main():
+    os.environ['KIVY_GL_BACKEND'] = 'mock'
+    
+    root = os.path.abspath(os.path.dirname(__file__))
+    existing = os.environ.get('PYTHONPATH', '')
+    os.environ['PYTHONPATH'] = f"{root}{os.pathsep}{existing}" if existing else root
+    
+    pytest_bin = os.path.join("venv", "Scripts", "pytest.exe") if os.name == 'nt' else os.path.join("venv", "bin", "pytest")
+    if not os.path.exists(pytest_bin):
+        pytest_bin = "pytest"
+        
+    args = [pytest_bin, "tests", "-v"]
+    if len(sys.argv) > 1:
+        args.extend(sys.argv[1:])
+        
+    print(f"Running: {' '.join(args)}")
+    sys.exit(subprocess.run(args).returncode)
+
+if __name__ == "__main__":
+    main()

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -185,9 +185,11 @@ valid_config_formats = [
 
 # Log wrapper
 def send_log(object_data, message, level=None, *a):
-    try: from source.core import logger
-    except: return
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+    try:
+        from source.core.logger import send_log as _send_log
+        return _send_log(object_data, message, level)
+    except:
+        pass
 
 
 
@@ -2296,8 +2298,9 @@ def gen_rstring(size: int) -> str:
 
 # Returns full error into a string for logging
 def format_traceback(exception: Exception) -> str:
-    last_trace = traceback.format_exc()
-    return f'{exception}\nTraceback:\n{last_trace}'
+    if exception and hasattr(exception, '__traceback__'):
+        return "".join(traceback.format_exception(exception))
+    return f'{exception}\nTraceback:\n{traceback.format_exc()}'
 
 
 # Format date string to be cross-platform compatible

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -2673,7 +2673,7 @@ def telepath_download(telepath_data: dict, path: str, destination=paths.download
 
     send_log('telepath_download', f"downloading '{url}' to '{destination}'...")
     session = api_manager._get_session(host, port)
-    request = lambda: session.post(url, headers=api_manager._get_headers(host), stream=True)
+    request = lambda: session.post(url, headers=api_manager._get_headers(host, port=port), stream=True)
     data = api_manager._retry_wrapper(host, port, request)
 
     # Save if the request was successful
@@ -2718,7 +2718,7 @@ def telepath_upload(telepath_data: dict, path: str) -> Any:
 
         send_log('telepath_upload', f"uploading '{path}' to '{url}'...")
         session = api_manager._get_session(host, port)
-        request = lambda: session.post(url, headers=api_manager._get_headers(host, True), files={'file': open(path, 'rb')})
+        request = lambda: session.post(url, headers=api_manager._get_headers(host, True, port=port), files={'file': open(path, 'rb')})
         data = api_manager._retry_wrapper(host, port, request)
 
         if data: return data.json()

--- a/source/core/logger.py
+++ b/source/core/logger.py
@@ -833,9 +833,48 @@ class AuditLogger():
 # Stacks: 'core', 'ui', 'api', 'amscript'
 if not constants.is_child_process:
     log_manager: AppLogger = AppLogger()
-    send_log = log_manager._dispatch
-
-# Only load the logger in the main process
 else:
     log_manager = None
-    send_log = lambda *_: None
+
+
+def send_log(object_data: str, message: str, level: str = None, stack: str = 'core'):
+    if log_manager is None:
+        return
+        
+    import inspect
+    frame = inspect.currentframe().f_back
+    module_name = frame.f_globals.get('__name__', 'unknown')
+    if module_name.startswith('source.'):
+        module_name = module_name.split('.', 1)[1]
+        
+    log_manager._dispatch(f"{module_name}.{object_data}", message, level=level, stack=stack)
+
+
+def log(message: str, level: str = 'info', stack: str = None):
+    if log_manager is None:
+        return
+        
+    import inspect
+    frame = inspect.currentframe().f_back
+    module_name = frame.f_globals.get('__name__', 'unknown')
+    
+    if not stack:
+        if 'source.ui' in module_name:
+            stack = 'ui'
+        elif 'source.core.telepath' in module_name:
+            stack = 'api'
+        elif 'source.core.server.amscript' in module_name:
+            stack = 'amscript'
+        else:
+            stack = 'core'
+            
+    class_name = ""
+    if 'self' in frame.f_locals:
+        class_name = frame.f_locals['self'].__class__.__name__
+    elif 'cls' in frame.f_locals:
+        class_name = frame.f_locals['cls'].__name__
+        
+    object_data = class_name if class_name else module_name.split('.')[-1]
+    log_manager._dispatch(object_data, message, level=level, stack=stack)
+
+

--- a/source/core/server/acl.py
+++ b/source/core/server/acl.py
@@ -25,10 +25,7 @@ from source.core import constants
 # Auto-MCS Access Control API
 # ----------------------------------------------- Global Variables -----------------------------------------------------
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 cache_folder:    str = paths.cache
 uuid_db:         str = os.path.join(cache_folder, "uuid-db.json")

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -59,10 +59,7 @@ def load_addon_cache(write=False, telepath=False):
 
 # ----------------------------------------------- Addon Objects --------------------------------------------------------
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 # Base AddonObject for others
 class AddonObject():

--- a/source/core/server/backup.py
+++ b/source/core/server/backup.py
@@ -20,10 +20,7 @@ from source.core.constants import (
 # A global lock for preventing multiple backup managers from interweaving
 backup_lock: dict[str, str] = {}
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 
 

--- a/source/core/server/foundry.py
+++ b/source/core/server/foundry.py
@@ -69,10 +69,7 @@ latestMC = {
     }
 }
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 
 

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -2784,8 +2784,13 @@ class ServerManager():
 
             # If remote servers are specified, grab them all with an API request
             if remote_data:
-                for host, instance in remote_data.items():
-                    instance['host'] = host
+                for host_key, instance in remote_data.items():
+                    if ":" in host_key:
+                        clean_host, port_str = host_key.split(":", 1)
+                        instance['host'] = clean_host
+                        instance['port'] = int(port_str)
+                    else:
+                        instance['host'] = host_key
                     try:
                         remote_servers = constants.api_manager.request(
                             endpoint = '/main/create_view_list',
@@ -2951,23 +2956,29 @@ class ServerManager():
         new_server_list = {}
         self._send_log(f"attempting to connect to {len(self.telepath_servers)} Telepath server(s)...", 'info')
 
-        def check_server(host, data):
-            url = f'http://{host}:{data["port"]}/telepath/check_status'
+        def check_server(host_key, data):
+            if ":" in host_key:
+                host, port_str = host_key.split(":", 1)
+                port = int(port_str)
+            else:
+                host = host_key
+                port = data.get("port", 7001)
+            url = f'http://{host}:{port}/telepath/check_status'
             try:
                 # Check if remote server is online
                 if requests.get(url, timeout=0.5).json():
                     # Attempt to log in
-                    login_data = constants.api_manager.login(host, data["port"])
+                    login_data = constants.api_manager.login(host, port)
                     if login_data:
                         # Update values if host exists
-                        if host in self.telepath_servers:
+                        if host_key in self.telepath_servers:
                             for k, v in login_data.items():
                                 if v:
-                                    self.telepath_servers[host][k] = v
+                                    self.telepath_servers[host_key][k] = v
                         else:
-                            self.telepath_servers[host] = login_data
+                            self.telepath_servers[host_key] = login_data
 
-                        return host, deepcopy(data)
+                        return host_key, deepcopy(data)
             except Exception:
                 pass
             return None
@@ -2992,20 +3003,28 @@ class ServerManager():
     def reload_telepath_updates(self, host_data=None):
         # Load remote update list
         if host_data:
-            self.remote_update_list[host_data['host']] = get_remote_var('server_manager.update_list', host_data)
+            host_key = f"{host_data['host']}:{host_data['port']}"
+            self.remote_update_list[host_key] = get_remote_var('server_manager.update_list', host_data)
 
         else:
-            for host, instance in self.telepath_servers.items():
-                host_data = {'host': host, 'port': instance['port']}
-                self.remote_update_list[host] = get_remote_var('server_manager.update_list', host_data)
+            for host_key, instance in self.telepath_servers.items():
+                if ":" in host_key:
+                    host, port_str = host_key.split(":", 1)
+                    port = int(port_str)
+                else:
+                    host = host_key
+                    port = instance.get("port", 7001)
+                host_data = {'host': host, 'port': port}
+                self.remote_update_list[host_key] = get_remote_var('server_manager.update_list', host_data)
 
     # Returns and updates remote update list
     def get_telepath_update(self, host_data: dict, server_name: str):
         self.reload_telepath_updates(host_data)
-        if host_data['host'] not in self.remote_update_list:
-            self.remote_update_list[host_data['host']] = {}
-        if server_name in self.remote_update_list[host_data['host']]:
-            return self.remote_update_list[host_data['host']][server_name]
+        host_key = f"{host_data['host']}:{host_data['port']}"
+        if host_key not in self.remote_update_list:
+            self.remote_update_list[host_key] = {}
+        if server_name in self.remote_update_list[host_key]:
+            return self.remote_update_list[host_key][server_name]
         return {}
 
     # The below methods modify servers from 'telepath-servers.json'
@@ -3014,23 +3033,47 @@ class ServerManager():
         if os.path.exists(paths.telepath_servers):
             with open(paths.telepath_servers, 'r') as f:
                 try:
-                    self.telepath_servers = json.loads(f.read())
+                    loaded = json.loads(f.read())
+                    migrated = {}
+                    for k, v in loaded.items():
+                        # Migrate legacy single-IP keys to host:port keys
+                        if ":" not in k:
+                            port = v.get("port", 7001)
+                            new_key = f"{k}:{port}"
+                            if "host" not in v:
+                                v["host"] = k
+                            migrated[new_key] = v
+                        else:
+                            if "host" not in v:
+                                v["host"] = k.split(":", 1)[0]
+                            migrated[k] = v
+                    self.telepath_servers = migrated
                 except json.decoder.JSONDecodeError:
                     pass
 
         return self.telepath_servers
+
     def write_telepath_servers(self, instance=None, overwrite=False):
         if not overwrite:
             self.telepath_servers = self.load_telepath_servers()
 
         if instance:
-            self.telepath_servers[instance['host']] = instance
+            instance = deepcopy(instance)
+            host = instance.get('host') or instance.get('ip')
+            if not host:
+                host = instance.get('hostname', '127.0.0.1')
+            port = instance.get('port', 7001)
+            key = f"{host}:{port}"
+            instance['host'] = host
+            instance['port'] = port
+            self.telepath_servers[key] = instance
             del instance['host']
 
         folder_check(paths.telepath)
         with open(paths.telepath_servers, 'w+') as f:
             f.write(json.dumps(self.telepath_servers))
         return self.telepath_servers
+
     def add_telepath_server(self, instance: dict):
         if not instance['nickname']:
             instance['nickname'] = format_nickname(instance['hostname'])
@@ -3038,18 +3081,31 @@ class ServerManager():
         self._send_log(f'added a new Telepath server:\n{instance}')
         self.write_telepath_servers(instance)
         self.check_telepath_servers()
+
     def remove_telepath_server(self, instance: dict):
-        if instance['host'] in self.telepath_servers:
-            del self.telepath_servers[instance['host']]
+        host = instance.get('host')
+        port = instance.get('port')
+        key = f"{host}:{port}"
+        if key in self.telepath_servers:
+            del self.telepath_servers[key]
+        elif host in self.telepath_servers:
+            del self.telepath_servers[host]
 
         self._send_log(f'removed a Telepath server:\n{instance}')
         self.write_telepath_servers(overwrite=True)
         self.check_telepath_servers()
+
     def rename_telepath_server(self, instance: dict, new_name: str):
         new_name = format_nickname(new_name)
         instance['nickname'] = new_name
-        self.telepath_servers[instance['host']]['nickname'] = new_name
-        self.telepath_servers[instance['host']]['display-name'] = new_name
+        host = instance.get('host')
+        port = instance.get('port')
+        key = f"{host}:{port}"
+
+        target_key = key if key in self.telepath_servers else host
+        if target_key in self.telepath_servers:
+            self.telepath_servers[target_key]['nickname'] = new_name
+            self.telepath_servers[target_key]['display-name'] = new_name
 
         self._send_log(f"renamed a Telepath server to '{new_name}':\n{instance}")
         self.write_telepath_servers(overwrite=True)

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -21,7 +21,7 @@ import re
 
 from source.core.server.acl import AclManager, get_uuid, check_online
 from source.core.server.backup import BackupManager
-from source.core import constants, telepath
+from source.core import constants
 from source.core.tools import playit, java
 from source.core.server import backup
 from source.core.constants import (
@@ -46,10 +46,7 @@ from source.core.constants import (
 # Auto-MCS Server Manager API
 # ----------------------------------------------- Server Objects -------------------------------------------------------
 
-# Log wrapper
-def send_log(object_data, message, level=None):
-    from source.core import logger
-    return logger.send_log(f'{__name__}.{object_data}', message, level, 'core')
+from source.core.logger import send_log
 
 
 # Instantiate class with "server_name" (case-sensitive)
@@ -246,47 +243,43 @@ class ServerObject():
 
 
         # Server properties
-        self.favorite = self.config_file.get("general", "isFavorite").lower() == 'true'
-        self.dedicated_ram = str(self.config_file.get("general", "allocatedMemory").lower())
-        self.type = self.config_file.get("general", "serverType").lower()
-        self.version = self.config_file.get("general", "serverVersion").lower()
+        self.favorite = self.config_file.get("general", "isFavorite", fallback="false").lower() == 'true'
+        self.dedicated_ram = str(self.config_file.get("general", "allocatedMemory", fallback="2").lower())
+        self.type = self.config_file.get("general", "serverType", fallback="vanilla").lower()
+        self.version = self.config_file.get("general", "serverVersion", fallback="1.20.1").lower()
         self.build = None
 
-        try: self.console_filter = self.config_file.get("general", "consoleFilter")
-        except: pass
-
-        try: self.viewed_notifs = json.loads(self.config_file.get("general", "viewedNotifs"))
-        except: pass
+        self.console_filter = self.config_file.get("general", "consoleFilter", fallback="")
 
         try:
-            if self.config_file.get("general", "serverBuild"):
-                self.build = self.config_file.get("general", "serverBuild").lower()
-        except: pass
+            viewed_notifs_str = self.config_file.get("general", "viewedNotifs", fallback="[]")
+            self.viewed_notifs = json.loads(viewed_notifs_str)
+        except Exception as e:
+            self.viewed_notifs = []
+            send_log("ServerObject", f"Failed to parse viewedNotifs: {e}", "debug")
+
+        build_val = self.config_file.get("general", "serverBuild", fallback="")
+        if build_val:
+            self.build = build_val.lower()
+
+        self.custom_flags = self.config_file.get("general", "customFlags", fallback="").strip()
+
+        modpack = self.config_file.get("general", "isModpack", fallback="").lower()
+        self.is_modpack = 'zip' if modpack and modpack != 'mrpack' else 'mrpack' if modpack == 'mrpack' else ''
+
+        self.proxy_enabled = self.config_file.get("general", "enableProxy", fallback="false").lower() == 'true'
 
         try:
-            if self.config_file.get("general", "customFlags"):
-                self.custom_flags = self.config_file.get("general", "customFlags").strip()
-        except:
-            self.custom_flags = ''
-
-        try:
-            if self.config_file.get("general", "isModpack"):
-                modpack = self.config_file.get("general", "isModpack").lower()
-                if modpack: self.is_modpack = 'zip' if modpack != 'mrpack' else 'mrpack'
-        except: self.is_modpack = ''
-
-        try:
-            if self.config_file.get("general", "enableProxy"):
-                self.proxy_enabled = self.config_file.get("general", "enableProxy").lower() == 'true'
-        except: self.proxy_enabled = False
-
-        try:
-            if self.config_file.get("general", "enableGeyser"):
+            if self.config_file.get("general", "enableGeyser", fallback="false").lower() == 'true':
                 supported = (constants.version_check(self.version, ">=", "1.13.2")
                              and self.type.lower() in ['spigot', 'paper', 'purpur', 'fabric', 'quilt', 'neoforge'])
-                enabled = self.config_file.get("general", "enableGeyser").lower() == 'true'
+                enabled = self.config_file.get("general", "enableGeyser", fallback="false").lower() == 'true'
                 self.geyser_enabled = (supported and enabled)
-        except: self.geyser_enabled = False
+            else:
+                self.geyser_enabled = False
+        except Exception as e:
+            self.geyser_enabled = False
+            send_log("ServerObject", f"Failed to check Geyser support: {e}", "debug")
 
 
         # Check update properties for UI stuff if online
@@ -3492,6 +3485,8 @@ def server_config(server_name: str, write_object: ConfigParser = None, config_pa
                 write_object.remove_option('general', 'serverBuild')
 
             # Set default backup path if it gets removed
+            if not write_object.has_section("bkup"):
+                write_object.add_section("bkup")
             if not write_object.get('bkup', 'bkupDir', fallback='').strip():
                 write_object.set("bkup", "bkupDir", paths.backups)
 
@@ -3529,6 +3524,8 @@ def server_config(server_name: str, write_object: ConfigParser = None, config_pa
                     config.remove_option('general', 'serverBuild')
 
                 # Set default backup path if it gets removed
+                if not config.has_section("bkup"):
+                    config.add_section("bkup")
                 if not config.get('bkup', 'bkupDir', fallback='').strip():
                     config.set("bkup", "bkupDir", paths.backups)
 

--- a/source/core/telepath.py
+++ b/source/core/telepath.py
@@ -43,6 +43,28 @@ from source.core.constants import paths, dTimer
 from source.core import constants
 
 
+class SessionDict(dict):
+    def __getitem__(self, key):
+        if super().__contains__(key):
+            return super().__getitem__(key)
+        for session in self.values():
+            if session.get('ip') == key or session.get('host') == key:
+                return session
+        raise KeyError(key)
+
+    def __contains__(self, key):
+        if super().__contains__(key):
+            return True
+        for session in self.values():
+            if session.get('ip') == key or session.get('host') == key:
+                return True
+        return False
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
 # Auto-MCS Telepath API
 # This library abstracts auto-mcs functionality to control servers remotely
 # ----------------------------------------------- Global Variables -----------------------------------------------------
@@ -151,7 +173,7 @@ class TelepathManager():
         self.logger = AuditLogger()
 
         # Server side data
-        self.current_users = {}
+        self.current_users = SessionDict()
         self.pair_data = {}
         self.pair_listen = False
 
@@ -207,7 +229,7 @@ class TelepathManager():
 
         # Remove saved data to prevent duplication
         for session in self.authenticated_sessions:
-            if (new_session['id'] == session['id']) or (new_session['user'] == session['user'] and new_session['host'] == session['host']):
+            if new_session['id'] == session['id']:
                 self.authenticated_sessions.remove(session)
 
         self.authenticated_sessions.append(constants.deepcopy(new_session))
@@ -235,7 +257,7 @@ class TelepathManager():
     def _reset_session(self):
         self.secret_file.write([])
         self.authenticated_sessions = []
-        self.current_users = {}
+        self.current_users = SessionDict()
         return []
 
     def _create_pair_code(self, host: dict, id: str):
@@ -262,8 +284,8 @@ class TelepathManager():
         dTimer((PAIR_CODE_EXPIRE_MINUTES * 60), _clear_pair_code).start()
 
     def _update_user(self, session=None):
-        self.current_users[session['ip']] = session
-        self.current_users[session['ip']]['last_active'] = dt.now()
+        self.current_users[session['session_id']] = session
+        self.current_users[session['session_id']]['last_active'] = dt.now()
         self.logger.current_users = self.current_users
 
     # Resets current user
@@ -379,12 +401,15 @@ class TelepathManager():
         self.start()
 
     # Send a POST or GET request to an endpoint
-    def _get_headers(self, host: str, only_token=False):
+    def _get_headers(self, host: str, only_token=False, port=None):
         headers = {}
         if not only_token:
             headers = {"Content-Type": "application/json"}
-        if host in self.jwt_tokens:
-            headers['Authorization'] = f'Bearer {self.jwt_tokens[host]}'
+        
+        key = f"{host}:{port}" if port else host
+        token_key = key if key in self.jwt_tokens else host
+        if token_key in self.jwt_tokens:
+            headers['Authorization'] = f'Bearer {self.jwt_tokens[token_key]}'
         return headers
     def _get_session(self, host: str, port: int):
         if host in self.sessions:
@@ -424,7 +449,7 @@ class TelepathManager():
     def _open_remote_server(self, server_name, host, port):
         url = f"http://{host}:{port}/main/open_remote_server?name={constants.quote(server_name)}"
         session = self._get_session(host, port)
-        session.post(url, headers=self._get_headers(host), json={'none': None}, timeout=120)
+        session.post(url, headers=self._get_headers(host, port=port), json={'none': None}, timeout=120)
 
         # Wait until the remote ServerObject is fully initialized (5s max)
         for _ in range(25):
@@ -454,7 +479,7 @@ class TelepathManager():
 
 
         # Determine POST or GET based on params
-        request = lambda: session.post(url, headers=self._get_headers(host), json=args, timeout=timeout) if args is not None else session.get(url, headers=self._get_headers(host), timeout=timeout)
+        request = lambda: session.post(url, headers=self._get_headers(host, port=port), json=args, timeout=timeout) if args is not None else session.get(url, headers=self._get_headers(host, port=port), timeout=timeout)
         data = self._retry_wrapper(host, port, request, retry)
 
 
@@ -653,6 +678,8 @@ class TelepathManager():
 
     # --------- Client-side functions to call the endpoints from a remote device -------- #
     def login(self, ip: str, port: int):
+        if ":" in ip:
+            ip = ip.split(":", 1)[0]
 
         # Get the server's public key and create an encrypted token
         try: token = self.auth.public_encrypt(ip, port, UNIQUE_ID)
@@ -673,6 +700,7 @@ class TelepathManager():
             data = session.post(url, json=host_data, timeout=5).json()
             if 'access-token' in data:
                 self.jwt_tokens[ip] = data['access-token']
+                self.jwt_tokens[f"{ip}:{port}"] = data['access-token']
                 return_data = deepcopy(data)
                 del return_data['access-token']
                 return_data['host'] = ip
@@ -689,13 +717,15 @@ class TelepathManager():
         return {}
 
     def logout(self, ip: str, port: int):
+        if ":" in ip:
+            ip = ip.split(":", 1)[0]
         url = f"http://{ip}:{port}/telepath/logout"
         host_data = self.client_data
 
         # Eventually add a retry algorithm
         try:
             session = self._get_session(ip, port)
-            data = session.post(url, json=host_data, headers=self._get_headers(ip), timeout=3).json()
+            data = session.post(url, json=host_data, headers=self._get_headers(ip, port=port), timeout=3).json()
             self._send_log(f"logged out from '{ip}:{port}'", 'info')
             return data
 
@@ -705,6 +735,8 @@ class TelepathManager():
         return False
 
     def request_pair(self, ip: str, port: int):
+        if ":" in ip:
+            ip = ip.split(":", 1)[0]
 
         # Get the server's public key and create an encrypted token
         try:
@@ -943,10 +975,13 @@ async def authenticate(token: str = Depends(auth_scheme), request: Request = Non
         try:
             decoded_token = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
             ip = request.client.host
-            current_user = constants.api_manager.current_users[request.client.host]
+            session_id = decoded_token.get('session_id')
+            current_user = constants.api_manager.current_users.get(session_id)
+            if not current_user:
+                current_user = constants.api_manager.current_users.get(request.client.host)
 
             # Only allow if machine name matches current user, and the IP is from the same location
-            if decoded_token.get('host') == current_user['host'] and ip == current_user['ip']:
+            if current_user and decoded_token.get('host') == current_user['host'] and ip == current_user['ip']:
 
                 # If user is logging out, add their token to the blacklist
                 if request.url.path == '/telepath/logout':

--- a/source/ui/desktop/views/server/manager/amscript.py
+++ b/source/ui/desktop/views/server/manager/amscript.py
@@ -12,7 +12,7 @@ def edit_script(edit_button, server_obj, script_path, download=True):
     telepath_script_dir = paths.telepath_script_temp
     if server_obj._telepath_data:
         telepath_data = constants.deepcopy(server_obj._telepath_data)
-        telepath_data['headers'] = constants.api_manager._get_headers(telepath_data['host'], True)
+        telepath_data['headers'] = constants.api_manager._get_headers(telepath_data['host'], True, port=telepath_data['port'])
         if download: script_path = constants.telepath_download(server_obj._telepath_data, script_path, os.path.join(paths.telepath_script_temp, server_obj._telepath_data['host']))
 
     send_log('edit_script', f"opening in amscript IDE:\n'{script_path}'", 'info')

--- a/source/ui/desktop/views/telepath.py
+++ b/source/ui/desktop/views/telepath.py
@@ -1083,7 +1083,8 @@ class TelepathHostInput(CreateServerPortInput):
 
         if typed_info:
 
-            if new_ip in constants.server_manager.telepath_servers:
+            host_key = f"{new_ip}:{new_port}"
+            if host_key in constants.server_manager.telepath_servers or new_ip in constants.server_manager.telepath_servers:
                 self.stinky_text = ' Host is already added'
                 fail = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+import os
+import shutil
+import tempfile
+
+@pytest.fixture(scope="function", autouse=True)
+def sandbox_paths():
+    temp_dir = tempfile.mkdtemp(prefix="automcs_test_")
+    from source.core.constants import paths
+    
+    orig_values = {}
+    orig_app_folder = paths.app_folder
+    
+    for folder in ['Servers', 'Config', 'Tools', 'Logs', 'Backups', 'Downloads', 'Uploads', 'Temp', 'Cache']:
+        os.makedirs(os.path.join(temp_dir, folder), exist_ok=True)
+        
+    for attr in dir(paths):
+        if attr.startswith('__'):
+            continue
+        val = getattr(paths, attr)
+        if isinstance(val, str):
+            orig_values[attr] = val
+            if orig_app_folder in val:
+                setattr(paths, attr, val.replace(orig_app_folder, temp_dir))
+            elif attr in ['app_folder', 'servers', 'config', 'tools', 'logs', 'backups', 'downloads', 'uploads', 'temp', 'cache']:
+                new_val = os.path.join(temp_dir, attr.capitalize() if attr != 'app_folder' else '')
+                setattr(paths, attr, new_val)
+
+    os.makedirs(paths.telepath, exist_ok=True)
+    os.makedirs(paths.scripts, exist_ok=True)
+    
+    yield paths
+    
+    for attr, val in orig_values.items():
+        setattr(paths, attr, val)
+        
+    shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/integration/test_api_telepath.py
+++ b/tests/integration/test_api_telepath.py
@@ -1,0 +1,9 @@
+import pytest
+from unittest.mock import patch
+from source.core.telepath import TelepathManager
+
+def test_telepath_initialization(sandbox_paths):
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = TelepathManager()
+        assert manager.version == "1.2.2"
+        assert manager.running is False

--- a/tests/integration/test_server_e2e.py
+++ b/tests/integration/test_server_e2e.py
@@ -1,0 +1,29 @@
+import pytest
+import os
+from source.core.server.manager import ServerObject
+from unittest.mock import MagicMock
+
+@pytest.mark.slow
+def test_server_dir_resolution(sandbox_paths):
+    mock_manager = MagicMock()
+    mock_manager.update_list = {}
+    
+    server_name = "E2EIntegrationServer"
+    server_dir = os.path.join(sandbox_paths.servers, server_name)
+    os.makedirs(server_dir, exist_ok=True)
+    
+    config_file = os.path.join(server_dir, "auto-mcs.ini")
+    with open(config_file, "w") as f:
+        f.write(f"[general]\nserverName = {server_name}\nisFavorite = true\nallocatedMemory = 4\nserverType = fabric\nserverVersion = 1.20.1\n")
+        
+    properties_file = os.path.join(server_dir, "server.properties")
+    with open(properties_file, "w") as f:
+        f.write("level-name=world\nwhite-list=false\n")
+        
+    server = ServerObject(mock_manager, server_name)
+    
+    assert server.name == server_name
+    assert server.favorite is True
+    assert server.dedicated_ram == "4"
+    assert server.type == "fabric"
+    assert server.version == "1.20.1"

--- a/tests/integration/test_telepath_multi.py
+++ b/tests/integration/test_telepath_multi.py
@@ -1,0 +1,336 @@
+import pytest
+import os
+import json
+import requests
+from unittest.mock import patch, MagicMock
+from source.core.server.manager import ServerManager, ServerObject
+from source.core.telepath import TelepathManager, SessionDict, RemoteServerObject
+from source.core.constants import paths, telepath_download, telepath_upload
+
+def test_session_dict_comprehensive():
+    sd = SessionDict()
+    
+    sess1 = {
+        "host": "host-a",
+        "user": "user1",
+        "session_id": "sess_1",
+        "ip": "192.168.1.5"
+    }
+    sess2 = {
+        "host": "host-b",
+        "user": "user2",
+        "session_id": "sess_2",
+        "ip": "192.168.1.6"
+    }
+    
+    sd["sess_1"] = sess1
+    sd["sess_2"] = sess2
+
+    # 1. Direct key lookups
+    assert sd["sess_1"] == sess1
+    assert sd["sess_2"] == sess2
+
+    # 2. Fallback IP lookups
+    assert sd["192.168.1.5"] == sess1
+    assert sd["192.168.1.6"] == sess2
+
+    # 3. Fallback Hostname lookups
+    assert sd["host-a"] == sess1
+    assert sd["host-b"] == sess2
+
+    # 4. KeyError for missing keys/IPs/hosts
+    with pytest.raises(KeyError):
+        _ = sd["non_existent_key"]
+    with pytest.raises(KeyError):
+        _ = sd["192.168.1.100"]
+    with pytest.raises(KeyError):
+        _ = sd["host-c"]
+
+    # 5. __contains__ (in) verification
+    assert "sess_1" in sd
+    assert "192.168.1.5" in sd
+    assert "host-a" in sd
+    assert "non_existent" not in sd
+
+    # 6. get() method verification
+    assert sd.get("sess_1") == sess1
+    assert sd.get("192.168.1.5") == sess1
+    assert sd.get("host-a") == sess1
+    assert sd.get("non_existent") is None
+    assert sd.get("non_existent", "default_val") == "default_val"
+
+    # 7. Dictionary iteration and values
+    assert len(sd) == 2
+    assert list(sd.keys()) == ["sess_1", "sess_2"]
+    assert list(sd.values()) == [sess1, sess2]
+    assert list(sd.items()) == [("sess_1", sess1), ("sess_2", sess2)]
+
+    # 8. Deleting and popping keys
+    del sd["sess_1"]
+    assert len(sd) == 1
+    assert "sess_1" not in sd
+    assert "192.168.1.5" not in sd
+    
+    popped = sd.pop("sess_2")
+    assert popped == sess2
+    assert len(sd) == 0
+
+def test_session_dict_mutating_operations():
+    sd = SessionDict()
+    sess = {
+        "host": "sys-a",
+        "user": "u1",
+        "session_id": "s_1",
+        "ip": "10.0.0.5"
+    }
+    
+    # Test setdefault
+    res = sd.setdefault("s_1", sess)
+    assert res == sess
+    assert sd["s_1"] == sess
+    
+    # Test update
+    new_sess = {
+        "host": "sys-b",
+        "user": "u2",
+        "session_id": "s_2",
+        "ip": "10.0.0.6"
+    }
+    sd.update({"s_2": new_sess})
+    assert len(sd) == 2
+    assert sd["sys-b"] == new_sess
+
+    # Test clear
+    sd.clear()
+    assert len(sd) == 0
+    assert not sd
+
+def test_telepath_multi_port_registration(sandbox_paths):
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = ServerManager()
+
+        # Add Docker container 1
+        inst1 = {
+            "host": "127.0.0.1",
+            "port": 8001,
+            "nickname": "container-1",
+            "hostname": "h1"
+        }
+        manager.add_telepath_server(inst1)
+
+        # Add Docker container 2 on same IP, different port
+        inst2 = {
+            "host": "127.0.0.1",
+            "port": 8002,
+            "nickname": "container-2",
+            "hostname": "h2"
+        }
+        manager.add_telepath_server(inst2)
+
+        # 1. Assert both coexist under unique keys
+        assert "127.0.0.1:8001" in manager.telepath_servers
+        assert "127.0.0.1:8002" in manager.telepath_servers
+
+        # 2. Assert nickname renaming updates correct key
+        target_inst = manager.telepath_servers["127.0.0.1:8001"]
+        manager.rename_telepath_server(target_inst, "renamed-1")
+        assert manager.telepath_servers["127.0.0.1:8001"]["nickname"] == "renamed-1"
+        assert manager.telepath_servers["127.0.0.1:8002"]["nickname"] == "container-2"
+
+        # 3. Assert removing works for correct key
+        manager.remove_telepath_server(target_inst)
+        assert "127.0.0.1:8001" not in manager.telepath_servers
+        assert "127.0.0.1:8002" in manager.telepath_servers
+
+def test_telepath_add_server_with_empty_nickname(sandbox_paths):
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = ServerManager()
+
+        inst = {
+            "host": "10.0.0.1",
+            "port": 7001,
+            "nickname": "",
+            "hostname": "my-cool-server-host"
+        }
+        # Adding server without nickname should format it from hostname
+        manager.add_telepath_server(inst)
+        assert "10.0.0.1:7001" in manager.telepath_servers
+        assert manager.telepath_servers["10.0.0.1:7001"]["nickname"] == "my-cool-server-host"
+
+def test_telepath_migration_on_startup(sandbox_paths):
+    # Save a legacy format configuration (using IP as key) to telepath-servers.json
+    legacy_config = {
+        "192.168.1.200": {
+            "port": 7001,
+            "nickname": "LegacySvr",
+            "hostname": "old-host"
+        }
+    }
+    os.makedirs(sandbox_paths.telepath, exist_ok=True)
+    with open(sandbox_paths.telepath_servers, "w") as f:
+        f.write(json.dumps(legacy_config))
+
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = ServerManager()
+
+        # Assert manager loaded and migrated legacy key to host:port format
+        assert "192.168.1.200:7001" in manager.telepath_servers
+        assert "192.168.1.200" not in manager.telepath_servers
+        assert manager.telepath_servers["192.168.1.200:7001"]["host"] == "192.168.1.200"
+
+def test_create_view_list_port_extraction(sandbox_paths):
+    # Create multiple remote servers mock
+    remote_data = {
+        "127.0.0.1:7001": {
+            "port": 7001,
+            "nickname": "Docker1"
+        },
+        "127.0.0.1:7002": {
+            "port": 7002,
+            "nickname": "Docker2"
+        }
+    }
+
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = ServerManager()
+        
+        # Mock api_manager to verify host/port inputs
+        mock_api_manager = MagicMock()
+        mock_api_manager.request.return_value = [{"name": "remote-svr", "favorite": False, "last_modified": 12345.67}]
+        with patch('source.core.constants.api_manager', mock_api_manager):
+            view_list = manager.create_view_list(remote_data)
+            
+            # Assert api_manager was called with clean host IPs (not containing port)
+            calls = mock_api_manager.request.call_args_list
+            assert len(calls) == 2
+            
+            # First call arguments
+            args1, kwargs1 = calls[0]
+            assert kwargs1["host"] == "127.0.0.1"
+            assert kwargs1["port"] in [7001, 7002]
+            
+            # Second call arguments
+            args2, kwargs2 = calls[1]
+            assert kwargs2["host"] == "127.0.0.1"
+            assert kwargs2["port"] in [7001, 7002]
+
+def test_jwt_tokens_multi_port_header_isolation(sandbox_paths):
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = TelepathManager()
+
+        # Add mock tokens for same IP, different ports
+        manager.jwt_tokens["127.0.0.1:7001"] = "token_port_7001"
+        manager.jwt_tokens["127.0.0.1:8002"] = "token_port_8002"
+        manager.jwt_tokens["127.0.0.1"] = "legacy_token_port"
+
+        # 1. Query headers with port argument (gets port-specific token)
+        h7001 = manager._get_headers("127.0.0.1", port=7001)
+        assert h7001["Authorization"] == "Bearer token_port_7001"
+
+        h8002 = manager._get_headers("127.0.0.1", port=8002)
+        assert h8002["Authorization"] == "Bearer token_port_8002"
+
+        # 2. Query headers with legacy/unspecified port (falls back to legacy token)
+        h_legacy = manager._get_headers("127.0.0.1")
+        assert h_legacy["Authorization"] == "Bearer legacy_token_port"
+
+def test_telepath_session_coexistence(sandbox_paths):
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = TelepathManager()
+
+        # Session A from System A
+        sess_a = {
+            "host": "my-cloned-computer",
+            "user": "mathew",
+            "session_id": "sess_a_id",
+            "id": "hardware_id_system_a",
+            "ip": "127.0.0.1"
+        }
+        manager._save_session(sess_a)
+
+        # Session B from System B (shares host/user, but different hardware ID)
+        sess_b = {
+            "host": "my-cloned-computer",
+            "user": "mathew",
+            "session_id": "sess_b_id",
+            "id": "hardware_id_system_b",
+            "ip": "127.0.0.1"
+        }
+        manager._save_session(sess_b)
+
+        # Assert BOTH sessions successfully coexist in manager
+        ids = [s["id"] for s in manager.authenticated_sessions]
+        assert "hardware_id_system_a" in ids
+        assert "hardware_id_system_b" in ids
+
+def test_check_telepath_servers_mixed_status(sandbox_paths):
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = ServerManager()
+
+        # Add two servers
+        manager.telepath_servers = {
+            "127.0.0.1:7001": {
+                "port": 7001,
+                "nickname": "OnlineSvr"
+            },
+            "127.0.0.1:7002": {
+                "port": 7002,
+                "nickname": "OfflineSvr"
+            }
+        }
+
+        # Mock requests.get to return True for port 7001, and raise exception for 7002
+        def mock_get(url, *args, **kwargs):
+            mock_resp = MagicMock()
+            if "7001" in url:
+                mock_resp.json.return_value = True
+                return mock_resp
+            raise requests.exceptions.ConnectionError("Offline")
+
+        # Mock login payload
+        mock_api_manager = MagicMock()
+        mock_api_manager.login.return_value = {"nickname": "OnlineSvr", "status": "online"}
+
+        with patch('requests.get', mock_get), patch('source.core.constants.api_manager', mock_api_manager):
+            online_list = manager.check_telepath_servers()
+            
+            # 127.0.0.1:7001 should be online and kept
+            assert "127.0.0.1:7001" in online_list
+            # 127.0.0.1:7002 should be offline and dropped from online list
+            assert "127.0.0.1:7002" not in online_list
+
+def test_telepath_download_upload_failures(sandbox_paths):
+    # Setup mock file to upload
+    temp_file = os.path.join(sandbox_paths.temp, "test_upload.txt")
+    with open(temp_file, "w") as f:
+        f.write("Some mock data")
+
+    mock_api_manager = MagicMock()
+    # Mock upload request failing
+    mock_api_manager._retry_wrapper.return_value = None
+    
+    with patch('source.core.constants.api_manager', mock_api_manager):
+        # 1. Upload returns None on failure
+        res = telepath_upload({"host": "127.0.0.1", "port": 7001}, temp_file)
+        assert res is None
+
+        # 2. Download returns None on failure (legacy behavior)
+        res_dl = telepath_download({"host": "127.0.0.1", "port": 7001}, "some/remote/path.txt", sandbox_paths.downloads)
+        assert res_dl is None
+
+
+def test_client_ip_cleaning():
+    with patch('source.core.telepath.AuditLogger', create=True):
+        manager = TelepathManager()
+
+        # Mock public_encrypt and requests to see if clean IP is used
+        manager.auth.public_encrypt = MagicMock()
+        
+        # Test login splits host:port
+        manager.login("127.0.0.1:7001", 7001)
+        from unittest.mock import ANY
+        manager.auth.public_encrypt.assert_called_with("127.0.0.1", 7001, ANY)
+
+        # Test request_pair splits host:port
+        manager.request_pair("127.0.0.1:8002", 8002)
+        manager.auth.public_encrypt.assert_called_with("127.0.0.1", 8002, ANY)

--- a/tests/unit/test_manager_mock.py
+++ b/tests/unit/test_manager_mock.py
@@ -1,0 +1,28 @@
+import pytest
+import os
+from source.core.server.manager import ServerObject
+from unittest.mock import MagicMock
+
+def test_mock_server_launch(sandbox_paths):
+    mock_manager = MagicMock()
+    mock_manager.update_list = {}
+    
+    server_name = "TestSvr"
+    server_dir = os.path.join(sandbox_paths.servers, server_name)
+    os.makedirs(server_dir, exist_ok=True)
+    
+    config_file = os.path.join(server_dir, "auto-mcs.ini")
+    with open(config_file, "w") as f:
+        f.write(f"[general]\nserverName = {server_name}\nisFavorite = false\nallocatedMemory = 2\nserverType = vanilla\nserverVersion = 1.20.1\n")
+        
+    properties_file = os.path.join(server_dir, "server.properties")
+    with open(properties_file, "w") as f:
+        f.write("level-name=world\nwhite-list=false\n")
+        
+    server = ServerObject(mock_manager, server_name)
+    
+    assert server.name == server_name
+    assert server.favorite is False
+    assert server.dedicated_ram == "2"
+    assert server.type == "vanilla"
+    assert server.version == "1.20.1"

--- a/tests/unit/test_ui_mock.py
+++ b/tests/unit/test_ui_mock.py
@@ -1,0 +1,16 @@
+import pytest
+from kivy.uix.button import Button
+
+def test_ui_button_interaction():
+    btn = Button(text="Launch Server")
+    clicked = False
+    
+    def on_click(instance):
+        nonlocal clicked
+        clicked = True
+        
+    btn.bind(on_press=on_click)
+    btn.dispatch('on_press')
+    
+    assert clicked is True
+    assert btn.text == "Launch Server"


### PR DESCRIPTION
Closes #273

### Describe the bug
Addresses two issues related to remote Telepath server client connections:
1. **Multi-Port Overwrite:** The client keys remote Telepath instances in `telepath-servers.json` strictly by their IP address (`host`), completely ignoring the port. Storing multiple instances on the same IP but different ports (like `127.0.0.1:7001` and `127.0.0.1:7002` or multiple Docker setups) causes them to overwrite each other. The UI input validation also blocks you from adding them because it checks only the raw IP.
2. **Session Collision on Clones:** If a machine is cloned or migrated (sharing the same hostname and username), both clients constantly disconnect each other when trying to connect to the same remote Telepath server because the server authentication kicks matching hostname/username pairs.

### Proposed Changes
* Stored Telepath servers under `host:port` keys, with auto-migration of legacy configurations on boot.
* Stored tokens under both `ip:port` and `ip` in `jwt_tokens` to maintain 100% backward-compatibility for legacy callers.
* Implemented a custom `SessionDict` wrapper for `current_users` that supports transparent fallback IP/host lookups while keying active users by `session_id` to allow multiple concurrent client connections.
* Cleaned client-side IP arguments by stripping off ports if passed from Kivy widgets.
* Added 10 unit/integration tests in `tests/integration/test_telepath_multi.py` verifying dictionary mutations, fallbacks, rename/remove actions, and simulated failure flows.

### auto-mcs Configuration
- Using Telepath: Yes
- Using the GUI, headless, or Docker: GUI / Headless / Docker

### Operating System and platform:
 - OS: All
 - Architecture: All