### PR TITLE
Telepath fixes

### DIFF
--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -2867,7 +2867,7 @@ def telepath_download(telepath_data: dict, path: str, destination=paths.download
     session = api_manager._get_session(host, port)
     request = lambda: session.post(
         api_manager._get_url(host, port, endpoint),
-        headers = api_manager._get_headers(host),
+        headers = api_manager._get_headers(host, port),
         stream = True
     )
     data = api_manager._retry_wrapper(host, port, request)
@@ -2915,7 +2915,7 @@ def telepath_upload(telepath_data: dict, path: str) -> Any:
         session = api_manager._get_session(host, port)
         request = lambda: session.post(
             api_manager._get_url(host, port, endpoint),
-            headers = api_manager._get_headers(host, True),
+            headers = api_manager._get_headers(host, port, True),
             files = {'file': open(path, 'rb')}
         )
         data = api_manager._retry_wrapper(host, port, request)

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -59,7 +59,7 @@ text_logo = [
 app_title = "auto-mcs"
 app_version = "2.4"
 ams_version = "1.6.1"
-telepath_version = "1.2.3"
+telepath_version = "1.3"
 
 # Various project URLs for additional functionality within the app
 project_repo:           str = "https://github.com/macarooni-man/auto-mcs"
@@ -2860,11 +2860,16 @@ def telepath_download(telepath_data: dict, path: str, destination=paths.download
 
     host = telepath_data['host']
     port = telepath_data['port']
-    url = f"http://{host}:{port}/main/download_file?file={quote(path)}"
+    endpoint = f"main/download_file?file={quote(path)}"
+    url = api_manager._get_url(host, port, endpoint)
 
     send_log('telepath_download', f"downloading '{url}' to '{destination}'...")
     session = api_manager._get_session(host, port)
-    request = lambda: session.post(url, headers=api_manager._get_headers(host), stream=True)
+    request = lambda: session.post(
+        api_manager._get_url(host, port, endpoint),
+        headers = api_manager._get_headers(host),
+        stream = True
+    )
     data = api_manager._retry_wrapper(host, port, request)
 
     # Save if the request was successful
@@ -2872,10 +2877,8 @@ def telepath_download(telepath_data: dict, path: str, destination=paths.download
 
         # File name input validation
         file_name = os.path.basename(rename if rename else path)
-        if '/' in file_name:
-            file_name = file_name.rsplit('/', 1)[-1]
-        elif '\\' in file_name:
-            file_name = file_name.rsplit('\\', 1)[-1]
+        if '/' in file_name:    file_name = file_name.rsplit('/', 1)[-1]
+        elif '\\' in file_name: file_name = file_name.rsplit('\\', 1)[-1]
 
         final_path = os.path.join(destination, file_name)
         folder_check(destination)
@@ -2905,11 +2908,16 @@ def telepath_upload(telepath_data: dict, path: str) -> Any:
 
         host = telepath_data['host']
         port = telepath_data['port']
-        url = f"http://{host}:{port}/main/upload_file?is_dir={is_dir}"
+        endpoint = f"main/upload_file?is_dir={is_dir}"
+        url = api_manager._get_url(host, port, endpoint)
 
         send_log('telepath_upload', f"uploading '{path}' to '{url}'...")
         session = api_manager._get_session(host, port)
-        request = lambda: session.post(url, headers=api_manager._get_headers(host, True), files={'file': open(path, 'rb')})
+        request = lambda: session.post(
+            api_manager._get_url(host, port, endpoint),
+            headers = api_manager._get_headers(host, True),
+            files = {'file': open(path, 'rb')}
+        )
         data = api_manager._retry_wrapper(host, port, request)
 
         if data: return data.json()

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -2965,24 +2965,25 @@ class ServerManager():
         self._send_log(f"attempting to connect to {len(self.telepath_servers)} Telepath server(s)...", 'info')
 
         def check_server(host, data):
-            url = f'http://{host}:{data["port"]}/telepath/check_status'
             try:
-                # Check if remote server is online
-                if requests.get(url, timeout=0.5).json():
-                    # Attempt to log in
-                    login_data = constants.api_manager.login(host, data["port"])
-                    if login_data:
-                        # Update values if host exists
-                        if host in self.telepath_servers:
-                            for k, v in login_data.items():
-                                if v:
-                                    self.telepath_servers[host][k] = v
-                        else:
-                            self.telepath_servers[host] = login_data
 
-                        return host, deepcopy(data)
+                # Attempt to log in
+                login_data = constants.api_manager.login(host, data["port"], 0.5)
+                if login_data:
+
+                    # Update values if host exists
+                    if host in self.telepath_servers:
+                        for k, v in login_data.items():
+                            if v:
+                                self.telepath_servers[host][k] = v
+                    else:
+                        self.telepath_servers[host] = login_data
+
+                    return host, deepcopy(data)
+
             except Exception:
                 pass
+
             return None
 
         # Use ThreadPoolExecutor to check multiple servers concurrently

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -2268,8 +2268,10 @@ class RemoteViewObject():
 
     def _is_favorite(self):
         try:
-            if self.name in self._telepath_data['added-servers']:
-                return self._telepath_data['added-servers'][self.name]['favorite']
+            key = f"{self._telepath_data['host']}:{self._telepath_data['port']}"
+            telepath_data = self._manager.telepath_servers[key]
+            if self.name in telepath_data['added-servers']:
+                return telepath_data['added-servers'][self.name]['favorite']
         except KeyError: pass
         return False
 

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -2797,8 +2797,7 @@ class ServerManager():
 
             # If remote servers are specified, grab them all with an API request
             if remote_data:
-                for host, instance in remote_data.items():
-                    instance['host'] = host
+                for instance in remote_data.values():
                     try:
                         remote_servers = constants.api_manager.request(
                             endpoint = '/main/create_view_list',
@@ -2949,8 +2948,8 @@ class ServerManager():
 
         # Make sure the server isn't already open
         if self.current_server and self.current_server._telepath_data:
-            new = f"{telepath_data['host']}/{telepath_data['name']}"
-            old = f"{self.current_server._telepath_data['host']}/{self.current_server._telepath_data['name']}"
+            new = (telepath_data['host'], telepath_data['port'], telepath_data['name'])
+            old = (self.current_server._telepath_data['host'], self.current_server._telepath_data['port'], self.current_server._telepath_data['name'])
             if new == old: return self.current_server
 
         self.current_server = telepath.RemoteServerObject(self, telepath_data)
@@ -2964,22 +2963,22 @@ class ServerManager():
         new_server_list = {}
         self._send_log(f"attempting to connect to {len(self.telepath_servers)} Telepath server(s)...", 'info')
 
-        def check_server(host, data):
+        def check_server(key, data):
             try:
 
                 # Attempt to log in
-                login_data = constants.api_manager.login(host, data["port"], 0.5)
+                login_data = constants.api_manager.login(data['host'], data['port'], 0.5)
                 if login_data:
 
                     # Update values if host exists
-                    if host in self.telepath_servers:
+                    if key in self.telepath_servers:
                         for k, v in login_data.items():
                             if v:
-                                self.telepath_servers[host][k] = v
+                                self.telepath_servers[key][k] = v
                     else:
-                        self.telepath_servers[host] = login_data
+                        self.telepath_servers[key] = login_data
 
-                    return host, deepcopy(data)
+                    return key, deepcopy(data)
 
             except Exception:
                 pass
@@ -3004,22 +3003,27 @@ class ServerManager():
 
     # Retrieves remote update list
     def reload_telepath_updates(self, host_data=None):
+
         # Load remote update list
         if host_data:
-            self.remote_update_list[host_data['host']] = get_remote_var('server_manager.update_list', host_data)
+            key = f"{host_data['host']}:{host_data['port']}"
+            self.remote_update_list[key] = get_remote_var('server_manager.update_list', host_data)
 
         else:
-            for host, instance in self.telepath_servers.items():
-                host_data = {'host': host, 'port': instance['port']}
-                self.remote_update_list[host] = get_remote_var('server_manager.update_list', host_data)
+            for key, instance in self.telepath_servers.items():
+                self.remote_update_list[key] = get_remote_var('server_manager.update_list', instance)
 
     # Returns and updates remote update list
     def get_telepath_update(self, host_data: dict, server_name: str):
+        key = f"{host_data['host']}:{host_data['port']}"
         self.reload_telepath_updates(host_data)
-        if host_data['host'] not in self.remote_update_list:
-            self.remote_update_list[host_data['host']] = {}
-        if server_name in self.remote_update_list[host_data['host']]:
-            return self.remote_update_list[host_data['host']][server_name]
+
+        if key not in self.remote_update_list:
+            self.remote_update_list[key] = {}
+
+        if server_name in self.remote_update_list[key]:
+            return self.remote_update_list[key][server_name]
+
         return {}
 
     # The below methods modify servers from 'telepath-servers.json'
@@ -3028,23 +3032,36 @@ class ServerManager():
         if os.path.exists(paths.telepath_servers):
             with open(paths.telepath_servers, 'r') as f:
                 try:
-                    self.telepath_servers = json.loads(f.read())
+                    loaded_servers = json.loads(f.read())
+                    self.telepath_servers = {}
+
+                    for host, instance in loaded_servers.items():
+                        if 'host' not in instance:
+                            instance['host'] = host
+
+                        key = f"{instance['host']}:{instance['port']}"
+                        self.telepath_servers[key] = instance
+
                 except json.decoder.JSONDecodeError:
                     pass
 
         return self.telepath_servers
+
     def write_telepath_servers(self, instance=None, overwrite=False):
         if not overwrite:
             self.telepath_servers = self.load_telepath_servers()
 
         if instance:
-            self.telepath_servers[instance['host']] = instance
-            del instance['host']
+            instance = deepcopy(instance)
+            key = f"{instance['host']}:{instance['port']}"
+            self.telepath_servers[key] = instance
 
         folder_check(paths.telepath)
         with open(paths.telepath_servers, 'w+') as f:
             f.write(json.dumps(self.telepath_servers))
+
         return self.telepath_servers
+
     def add_telepath_server(self, instance: dict):
         if not instance['nickname']:
             instance['nickname'] = format_nickname(instance['hostname'])
@@ -3052,18 +3069,22 @@ class ServerManager():
         self._send_log(f'added a new Telepath server:\n{instance}')
         self.write_telepath_servers(instance)
         self.check_telepath_servers()
+
     def remove_telepath_server(self, instance: dict):
-        if instance['host'] in self.telepath_servers:
-            del self.telepath_servers[instance['host']]
+        key = f"{instance['host']}:{instance['port']}"
+        if key in self.telepath_servers:
+            del self.telepath_servers[key]
 
         self._send_log(f'removed a Telepath server:\n{instance}')
         self.write_telepath_servers(overwrite=True)
         self.check_telepath_servers()
+
     def rename_telepath_server(self, instance: dict, new_name: str):
+        key = f"{instance['host']}:{instance['port']}"
         new_name = format_nickname(new_name)
         instance['nickname'] = new_name
-        self.telepath_servers[instance['host']]['nickname'] = new_name
-        self.telepath_servers[instance['host']]['display-name'] = new_name
+        self.telepath_servers[key]['nickname'] = new_name
+        self.telepath_servers[key]['display-name'] = new_name
 
         self._send_log(f"renamed a Telepath server to '{new_name}':\n{instance}")
         self.write_telepath_servers(overwrite=True)
@@ -4186,7 +4207,7 @@ def get_server_icon(server_name: str, telepath_data: dict, overwrite=False):
         return None
 
     try:
-        name = f"{telepath_data['host'].replace('/', '+')}+{server_name}"
+        name = f"{telepath_data['host'].replace('/', '+')}+{telepath_data['port']}+{server_name}"
         icon_cache = os.path.join(paths.cache, 'icons')
         final_path = os.path.join(icon_cache, name)
 

--- a/source/core/telepath.py
+++ b/source/core/telepath.py
@@ -395,9 +395,49 @@ class TelepathManager():
             session = self.sessions[host]['session']
         else:
             session = requests.Session()
-            self.sessions[host] = {'port': port, 'session': session}
+            self.sessions[host] = {'port': port, 'scheme': 'http', 'session': session}
             self._send_log(f"opening session to '{host}'", 'info')
         return session
+
+    def _get_url(self, host: str, port: int, endpoint: str):
+        if endpoint.startswith('/'):
+            endpoint = endpoint[1:]
+
+        scheme = self.sessions.get(host, {}).get('scheme', 'http')
+        return f"{scheme}://{host}:{port}/{endpoint}"
+
+    def _negotiate_session(self, host: str, port: int, timeout=3):
+        session = self._get_session(host, port)
+
+        for scheme in ('https', 'http'):
+            self.sessions[host]['scheme'] = scheme
+
+            try:
+                data = session.get(self._get_url(host, port, 'telepath/check_status'), timeout=timeout)
+
+                # If the server answered, don't downgrade based on an application-level error
+                if data.status_code == 200 and data.json() is True:
+                    self._send_log(f"using {scheme.upper()} for session to '{host}:{port}'", 'info')
+                    return True
+
+                return False
+
+            except requests.exceptions.SSLError as e:
+                ssl_error = str(e).lower()
+
+                # Never downgrade when HTTPS certificate verification fails
+                if 'certificate' in ssl_error or 'hostname' in ssl_error:
+                    self._send_log(f"failed to verify HTTPS session to '{host}:{port}': {constants.format_traceback(e)}", 'error')
+                    return False
+
+            except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
+                pass
+
+            except ValueError:
+                return False
+
+        return False
+
     def _retry_wrapper(self, host: str, port: int, request_func, retry=True):
         try:
             data = request_func()
@@ -425,8 +465,9 @@ class TelepathManager():
             data = None
 
         return data
+
     def _open_remote_server(self, server_name, host, port):
-        url = f"http://{host}:{port}/main/open_remote_server?name={constants.quote(server_name)}"
+        url = self._get_url(host, port, f'main/open_remote_server?name={constants.quote(server_name)}')
         session = self._get_session(host, port)
         session.post(url, headers=self._get_headers(host), json={'none': None}, timeout=120)
 
@@ -435,11 +476,13 @@ class TelepathManager():
             if constants.server_manager.current_server._check_object_init():
                 break
             time.sleep(0.2)
+
     def _get_previous_server(self, host: str):
         server_obj = constants.server_manager.current_server
         if server_obj:
             if server_obj._telepath_data and server_obj._telepath_data['host'] == host:
                 return server_obj.name
+
     def request(self, endpoint: str, host=None, port=None, args=None, timeout=120, retry=True):
         # Format endpoint
         if endpoint.startswith('/'):
@@ -453,12 +496,22 @@ class TelepathManager():
 
 
         # Check if session exists
-        url = f"http://{host}:{port}/{endpoint}"
         session = self._get_session(host, port)
 
-
         # Determine POST or GET based on params
-        request = lambda: session.post(url, headers=self._get_headers(host), json=args, timeout=timeout) if args is not None else session.get(url, headers=self._get_headers(host), timeout=timeout)
+        request = lambda: session.post(
+            self._get_url(host, port, endpoint),
+            headers = self._get_headers(host),
+            json = args,
+            timeout = timeout
+
+        ) if args is not None \
+        else session.get(
+            self._get_url(host, port, endpoint),
+            headers = self._get_headers(host),
+            timeout = timeout
+        )
+
         data = self._retry_wrapper(host, port, request, retry)
 
 
@@ -656,15 +709,19 @@ class TelepathManager():
 
 
     # --------- Client-side functions to call the endpoints from a remote device -------- #
-    def login(self, ip: str, port: int):
+    def login(self, ip: str, port: int, timeout=3):
+
+        # Negotiate HTTPS first, and fall back to legacy HTTP
+        if not self._negotiate_session(ip, port, timeout):
+            return {}
 
         # Get the server's public key and create an encrypted token
-        try: token = self.auth.public_encrypt(ip, port, UNIQUE_ID)
+        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID)
         except AttributeError as e:
             self._send_log(f"failed to get a public key from '{ip}:{port}': {constants.format_traceback(e)}", 'error')
             return {}
 
-        url = f"http://{ip}:{port}/telepath/login"
+        url = self._get_url(ip, port, 'telepath/login')
         host_data = {
             'host': self.client_data,
             'id_hash': token
@@ -693,7 +750,7 @@ class TelepathManager():
         return {}
 
     def logout(self, ip: str, port: int):
-        url = f"http://{ip}:{port}/telepath/logout"
+        url = self._get_url(ip, port, 'telepath/logout')
         host_data = self.client_data
 
         # Eventually add a retry algorithm
@@ -710,13 +767,16 @@ class TelepathManager():
 
     def request_pair(self, ip: str, port: int):
 
+        # Negotiate HTTPS first, and fall back to legacy HTTP
+        if not self._negotiate_session(ip, port):
+            return None
+
         # Get the server's public key and create an encrypted token
-        try:
-            token = self.auth.public_encrypt(ip, port, UNIQUE_ID)
+        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID)
         except AttributeError:
             return None
 
-        url = f"http://{ip}:{port}/telepath/request_pair"
+        url = self._get_url(ip, port, 'telepath/request_pair')
         host_data = {
             'host': self.client_data,
             'id_hash': token
@@ -736,13 +796,12 @@ class TelepathManager():
     def submit_pair(self, ip: str, port: int, code: str):
 
         # Get the server's public key and create an encrypted token
-        try:
-            token = self.auth.public_encrypt(ip, port, UNIQUE_ID)
+        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID)
         except AttributeError as e:
             self._send_log(f"failed to get a public key from '{ip}:{port}': {constants.format_traceback(e)}", 'error')
             return None
 
-        url = f"http://{ip}:{port}/telepath/submit_pair?code={code}"
+        url = self._get_url(ip, port, f'telepath/submit_pair?code={code}')
         host_data = {
             'host': self.client_data,
             'id_hash': token
@@ -848,11 +907,12 @@ class AuthHandler():
 
 
     # Use this to retrieve a public key from the server, and encrypt & return the content
-    def public_encrypt(self, ip: str, port: int, content: str or int) -> dict:
+    def public_encrypt(self, url: str, content: str or int) -> dict:
         content = str(content)
 
         # Retrieve public key PEM and convert it back to a Python object
-        pem = requests.get(f"http://{ip}:{port}/telepath/get_public_key").json()
+        # Requires a pre-constructed '/telepath/get_public_key' URL
+        pem = requests.get(url).json()
         public_key = serialization.load_pem_public_key(
             pem.encode('utf-8'),
             backend = default_backend()

--- a/source/core/telepath.py
+++ b/source/core/telepath.py
@@ -207,11 +207,11 @@ class TelepathManager():
             'telepath-version': self.version
         }
 
-    def _save_session(self, new_session: dict):
+    def _save_session(self, new_session: dict, user_id: str):
 
-        # Remove saved data to prevent duplication
-        for session in self.authenticated_sessions:
-            if (new_session['id'] == session['id']) or (new_session['user'] == session['user'] and new_session['host'] == session['host']):
+        # Remove saved data from the same client to prevent duplication
+        for session in self.authenticated_sessions.copy():
+            if self._verify_id(user_id, session['id']):
                 self.authenticated_sessions.remove(session)
 
         self.authenticated_sessions.append(constants.deepcopy(new_session))
@@ -293,7 +293,7 @@ class TelepathManager():
                 # Log out user if they are connected and disabled
                 if disabled:
                     for user in self.current_users.values():
-                        if user['user'] == session['user'] and user['host'] == session['host']:
+                        if user['id'] == session['id']:
 
                             # Show banner on logout
                             constants.telepath_banner(f"'${user['host']}/{user['user']}$' logged out", False)
@@ -383,19 +383,21 @@ class TelepathManager():
         self.start()
 
     # Send a POST or GET request to an endpoint
-    def _get_headers(self, host: str, only_token=False):
+    def _get_headers(self, host: str, port: int, only_token=False):
         headers = {}
         if not only_token:
             headers = {"Content-Type": "application/json"}
-        if host in self.jwt_tokens:
-            headers['Authorization'] = f'Bearer {self.jwt_tokens[host]}'
+        if (host, port) in self.jwt_tokens:
+            headers['Authorization'] = f'Bearer {self.jwt_tokens[(host, port)]}'
         return headers
+
     def _get_session(self, host: str, port: int):
-        if host in self.sessions:
-            session = self.sessions[host]['session']
+        key = (host, port)
+        if key in self.sessions:
+            session = self.sessions[key]['session']
         else:
             session = requests.Session()
-            self.sessions[host] = {'port': port, 'scheme': 'http', 'session': session}
+            self.sessions[key] = {'host': host, 'port': port, 'scheme': 'http', 'session': session}
             self._send_log(f"opening session to '{host}'", 'info')
         return session
 
@@ -403,14 +405,14 @@ class TelepathManager():
         if endpoint.startswith('/'):
             endpoint = endpoint[1:]
 
-        scheme = self.sessions.get(host, {}).get('scheme', 'http')
+        scheme = self.sessions.get((host, port), {}).get('scheme', 'http')
         return f"{scheme}://{host}:{port}/{endpoint}"
 
     def _negotiate_session(self, host: str, port: int, timeout=3):
         session = self._get_session(host, port)
 
         for scheme in ('https', 'http'):
-            self.sessions[host]['scheme'] = scheme
+            self.sessions[(host, port)]['scheme'] = scheme
 
             try:
                 data = session.get(self._get_url(host, port, 'telepath/check_status'), timeout=timeout)
@@ -446,7 +448,7 @@ class TelepathManager():
 
                     # On 401, try to re-authenticate and open the previous server
                     if self.login(host, port):
-                        force_server = self._get_previous_server(host)
+                        force_server = self._get_previous_server(host, port)
                         if force_server:
                             self._open_remote_server(force_server, host, port)
 
@@ -469,7 +471,7 @@ class TelepathManager():
     def _open_remote_server(self, server_name, host, port):
         url = self._get_url(host, port, f'main/open_remote_server?name={constants.quote(server_name)}')
         session = self._get_session(host, port)
-        session.post(url, headers=self._get_headers(host), json={'none': None}, timeout=120)
+        session.post(url, headers=self._get_headers(host, port), json={'none': None}, timeout=120)
 
         # Wait until the remote ServerObject is fully initialized (5s max)
         for _ in range(25):
@@ -477,11 +479,12 @@ class TelepathManager():
                 break
             time.sleep(0.2)
 
-    def _get_previous_server(self, host: str):
+    def _get_previous_server(self, host: str, port: int):
         server_obj = constants.server_manager.current_server
         if server_obj:
-            if server_obj._telepath_data and server_obj._telepath_data['host'] == host:
-                return server_obj.name
+            if server_obj._telepath_data:
+                if server_obj._telepath_data['host'] == host and server_obj._telepath_data['port'] == port:
+                    return server_obj.name
 
     def request(self, endpoint: str, host=None, port=None, args=None, timeout=120, retry=True):
         # Format endpoint
@@ -501,14 +504,14 @@ class TelepathManager():
         # Determine POST or GET based on params
         request = lambda: session.post(
             self._get_url(host, port, endpoint),
-            headers = self._get_headers(host),
+            headers = self._get_headers(host, port),
             json = args,
             timeout = timeout
 
         ) if args is not None \
         else session.get(
             self._get_url(host, port, endpoint),
-            headers = self._get_headers(host),
+            headers = self._get_headers(host, port),
             timeout = timeout
         )
 
@@ -528,15 +531,15 @@ class TelepathManager():
         return json_data
 
     def close_sessions(self):
-        for host, data in self.sessions.items():
+        for key, data in self.sessions.items():
 
             # Log out if authenticated to host
-            if host in self.jwt_tokens:
-                self.logout(host, data['port'])
+            if key in self.jwt_tokens:
+                self.logout(data['host'], data['port'])
 
             # Close the requests session
             data['session'].close()
-            self._send_log(f"closed session to '{host}:{data['port']}'", 'info')
+            self._send_log(f"closed session to '{data['host']}:{data['port']}'", 'info')
 
 
     # -------- Internal endpoints to authenticate with Telepath -------- #
@@ -615,7 +618,7 @@ class TelepathManager():
 
                         # Call function to write this data to a file
                         session = {'host': host['host'], 'user': host['user'], 'session_id': host['session_id'], 'id': self.pair_data['id'], 'ip': ip, 'disabled': False}
-                        self._save_session(session)
+                        self._save_session(session, id)
                         self._update_user(session)
                         self.pair_data = {}
 
@@ -733,7 +736,7 @@ class TelepathManager():
             session = self._get_session(ip, port)
             data = session.post(url, json=host_data, timeout=5).json()
             if 'access-token' in data:
-                self.jwt_tokens[ip] = data['access-token']
+                self.jwt_tokens[(ip, port)] = data['access-token']
                 return_data = deepcopy(data)
                 del return_data['access-token']
                 return_data['host'] = ip
@@ -756,7 +759,7 @@ class TelepathManager():
         # Eventually add a retry algorithm
         try:
             session = self._get_session(ip, port)
-            data = session.post(url, json=host_data, headers=self._get_headers(ip), timeout=3).json()
+            data = session.post(url, json=host_data, headers=self._get_headers(ip, port), timeout=3).json()
             self._send_log(f"logged out from '{ip}:{port}'", 'info')
             return data
 
@@ -811,7 +814,7 @@ class TelepathManager():
         try:
             data = requests.post(url, json=host_data).json()
             if 'access-token' in data:
-                self.jwt_tokens[ip] = data['access-token']
+                self.jwt_tokens[(ip, port)] = data['access-token']
                 return_data = deepcopy(data)
                 del return_data['access-token']
                 return_data['host'] = ip

--- a/source/ui/amseditor.py
+++ b/source/ui/amseditor.py
@@ -5101,13 +5101,16 @@ def ipc_save_script(cache_dir: str, script_path: str, script_contents: str, ipc_
     if telepath_data and script_path.startswith(telepath_script_dir):
         host = telepath_data['host']
         port = telepath_data['port']
-        url = f"http://{host}:{port}"
         data = ipc_functions['telepath_upload'](telepath_data, script_path)
 
         # If the file was uploaded, import the script
         if 'path' in data:
             session = ipc_functions['api_manager']._get_session(host, port)
-            request = lambda: session.post(f'{url}/ScriptManager/import_script', headers=ipc_functions['api_manager']._get_headers(host), json={'script': data['path']})
+            request = lambda: session.post(
+                ipc_functions['api_manager']._get_url(host, port, 'ScriptManager/import_script'),
+                headers = ipc_functions['api_manager']._get_headers(host),
+                json = {'script': data['path']}
+            )
             data = ipc_functions['api_manager']._retry_wrapper(host, port, request)
 
 

--- a/source/ui/amseditor.py
+++ b/source/ui/amseditor.py
@@ -5108,7 +5108,7 @@ def ipc_save_script(cache_dir: str, script_path: str, script_contents: str, ipc_
             session = ipc_functions['api_manager']._get_session(host, port)
             request = lambda: session.post(
                 ipc_functions['api_manager']._get_url(host, port, 'ScriptManager/import_script'),
-                headers = ipc_functions['api_manager']._get_headers(host),
+                headers = ipc_functions['api_manager']._get_headers(host, port),
                 json = {'script': data['path']}
             )
             data = ipc_functions['api_manager']._retry_wrapper(host, port, request)

--- a/source/ui/desktop/views/server/manager/amscript.py
+++ b/source/ui/desktop/views/server/manager/amscript.py
@@ -12,8 +12,10 @@ def edit_script(edit_button, server_obj, script_path, download=True):
     telepath_script_dir = paths.telepath_script_temp
     if server_obj._telepath_data:
         telepath_data = constants.deepcopy(server_obj._telepath_data)
-        telepath_data['headers'] = constants.api_manager._get_headers(telepath_data['host'], True)
-        if download: script_path = constants.telepath_download(server_obj._telepath_data, script_path, os.path.join(paths.telepath_script_temp, server_obj._telepath_data['host']))
+        telepath_data['headers'] = constants.api_manager._get_headers(telepath_data['host'], telepath_data['port'], True)
+        if download:
+            temp_folder = os.path.join(paths.telepath_script_temp, server_obj._telepath_data['host'], str(server_obj._telepath_data['port']))
+            script_path = constants.telepath_download(server_obj._telepath_data, script_path, temp_folder)
 
     send_log('edit_script', f"opening in amscript IDE:\n'{script_path}'", 'info')
 

--- a/source/ui/desktop/views/telepath.py
+++ b/source/ui/desktop/views/telepath.py
@@ -138,7 +138,8 @@ class InstanceButton(HoverButton):
             self.background_normal = os.path.join(paths.ui_assets, 'list_button_disabled.png')
 
         try:
-            if self.properties['host'] in constants.server_manager.online_telepath_servers:
+            key = f"{self.properties['host']}:{self.properties['port']}"
+            if key in constants.server_manager.online_telepath_servers:
                 self.connect_color = (0.529, 1, 0.729, 1)
                 self.subtitle.color = self.connect_color
                 self.subtitle.default_opacity = 0.8
@@ -335,9 +336,8 @@ class TelepathInstanceScreen(MenuBackground):
 
         self.page_switcher.update_index(self.current_page, self.max_pages)
         page_list = []
-        for k, v in constants.deepcopy(results).items():
-            v['host'] = k
-            page_list.append(v)
+        for instance in constants.deepcopy(results).values():
+            page_list.append(instance)
         page_list = page_list[(self.page_size * self.current_page) - self.page_size:self.page_size * self.current_page]
 
         self.scroll_layout.clear_widgets()
@@ -366,7 +366,8 @@ class TelepathInstanceScreen(MenuBackground):
 
                     def unpair(*a):
                         # Log out if possible
-                        if data['host'] in constants.api_manager.jwt_tokens:
+                        key = (data['host'], data['port'])
+                        if key in constants.api_manager.jwt_tokens:
                             constants.api_manager.logout(data['host'], data['port'])
 
                         constants.server_manager.remove_telepath_server(data)
@@ -1082,7 +1083,8 @@ class TelepathHostInput(CreateServerPortInput):
 
         if typed_info:
 
-            if new_ip in constants.server_manager.telepath_servers:
+            key = f"{new_ip}:{new_port}"
+            if key in constants.server_manager.telepath_servers:
                 self.stinky_text = ' Host is already added'
                 fail = True
 

--- a/source/ui/desktop/views/telepath.py
+++ b/source/ui/desktop/views/telepath.py
@@ -987,7 +987,7 @@ class TelepathHostInput(CreateServerPortInput):
         self.port = ''
         super().__init__(**kwargs)
         self.checking = False
-        self.hint_text = f"enter IPv4  (default port :{constants.api_manager.default_port})"
+        self.hint_text = f"enter host/IPv4  (default port :{constants.api_manager.default_port})"
         self.bind(on_text_validate=self.check_connection)
 
     def check_connection(self, *a):
@@ -1074,10 +1074,9 @@ class TelepathHostInput(CreateServerPortInput):
             new_port = default_port
 
         # Input validation
-        try: port_check = ((int(new_port) < 1024) or (int(new_port) > 65535))
+        try: port_check = ((int(new_port) < 1024 and int(new_port) != 443) or (int(new_port) > 65535))
         except: port_check = True
-        ip_check = (constants.check_ip(new_ip) and '.' in typed_info) or new_ip.replace('-', '').replace('.',
-                                                                                                         '').isalpha()
+        ip_check = (constants.check_ip(new_ip) and '.' in typed_info) or new_ip.replace('-', '').replace('.', '').isalnum()
         self.stinky_text = ''
         fail = False
 
@@ -1364,7 +1363,7 @@ class TelepathManagerScreen(MenuBackground):
             self.pair_layout = FloatLayout()
             self.pair_layout.opacity = 0
             self.pair_layout.add_widget(InputLabel(pos_hint={"center_x": 0.5, "center_y": 0.55}))
-            self.pair_layout.add_widget(HeaderText("Enter the IPv4/port you wish to connect", 'make sure "share this instance" is enabled on the server', (0, 0.75)))
+            self.pair_layout.add_widget(HeaderText("Enter the host/port you wish to connect", 'make sure "share this instance" is enabled on the server', (0, 0.75)))
             self.host_input = TelepathHostInput(pos_hint={"center_x": 0.5, "center_y": 0.45}, text='')
             self.pair_layout.add_widget(self.host_input)
 

--- a/source/ui/desktop/views/telepath.py
+++ b/source/ui/desktop/views/telepath.py
@@ -1635,7 +1635,7 @@ class TelepathPair():
 
         # Normal operation
         try:
-            current_user = constants.api_manager.current_users[self.pair_data['host']['ip']]
+            current_user = constants.api_manager.current_users.get(self.pair_data['host']['ip'])
             if current_user and current_user['host'] == self.pair_data['host']['host'] and current_user['user'] == self.pair_data['host']['user']:
                 message = f"Successfully paired with '${current_user['host']}/{current_user['user']}$'"
                 color = (0.553, 0.902, 0.675, 1)

--- a/source/ui/desktop/widgets/menus.py
+++ b/source/ui/desktop/widgets/menus.py
@@ -301,8 +301,12 @@ class TelepathDropButton(DropButton):
         telepath_data = self.options_list[item]
 
         if telepath_data:
-            telepath_data['host'] = item
-            return telepath_data['nickname'] or item, False
+            nickname = telepath_data['nickname']
+            if nickname:
+                duplicates = sum(1 for data in self.options_list.values() if data and data['nickname'] == nickname)
+                if duplicates == 1: return nickname, False
+
+            return item, False
 
         return item, True
 
@@ -322,7 +326,7 @@ class TelepathDropButton(DropButton):
         # Button click behavior
         def set_var(result):
             for k, v in self.options_list.items():
-                if (k == 'this machine' == result) or (v and (('.' in result and result == k) or (result == v['nickname']))):
+                if (k == 'this machine' == result) or (v and (result == k or result == v['nickname'])):
                     foundry.new_server_info['_telepath_data'] = v
                     if type in ['import', 'clone']:
                         foundry.import_data['_telepath_data'] = v

--- a/source/ui/headless/utility.py
+++ b/source/ui/headless/utility.py
@@ -743,6 +743,7 @@ def telepath_pair(data=None):
             time.sleep(1)
             timeout += 1
             if timeout >= total:
+                constants.api_manager.pair_listen = False
                 return final_text
     except KeyboardInterrupt:
         constants.api_manager.pair_listen = False
@@ -763,11 +764,12 @@ def telepath_pair(data=None):
         time.sleep(1)
         timeout += 1
         if timeout >= 60:
+            constants.api_manager.pair_listen = False
             return final_text
 
-    user = constants.api_manager.current_users[data['host']['ip']]
-    host = user["host"] if user["host"] else "Unknown"
+    user = constants.api_manager.current_users.get(data['host']['ip'])
     if user:
+        host = user["host"] if user["host"] else "Unknown"
         final_text = [('normal', 'Successfully paired with '), ('telepath_host', f'{host}/{user["user"]} '), ('help', f'({user["ip"]})')]
 
     constants.api_manager.pair_listen = False

--- a/source/ui/headless/utility.py
+++ b/source/ui/headless/utility.py
@@ -897,7 +897,7 @@ def telepath_revoke(user_id=None):
 
         # Force logout if they are logged in
         for session in constants.api_manager.current_users.values():
-            if user['user'] == session['user'] and user['host'] == session['host']:
+            if user['id'] == session['id']:
                 constants.api_manager._force_logout(session['session_id'])
                 break
 


### PR DESCRIPTION
## Summary

This PR updates Telepath transport and session handling while preserving the existing protocol flow and backwards compatibility with HTTP configurations.

- Adds HTTPS-first connection negotiation with fallback to legacy HTTP when TLS is unavailable
- Prevents HTTP downgrade when HTTPS certificate verification fails
- Adds hostname support and allows HTTPS on port 443
- Updates Telepath endpoint state to use `host:port` instead of only `host`, fixing collisions when multiple endpoints share an address
- Migrates existing saved Telepath instances to the new endpoint format automatically
- Tracks HTTP sessions and JWTs per endpoint so separate ports no longer share connection/authentication state
- Fixes #273 by using Telepath's existing `UNIQUE_ID` identity when deduplicating paired clients instead of hostname/username
- Fixes pairing expiration handling in both desktop and headless interfaces

The active server-side Telepath session model is otherwise unchanged.

## Testing

Manually tested between macOS and Linux Telepath instances:

- Existing paired instances reconnect correctly after upgrading
- Existing saved Telepath configuration migrates and persists across restarts
- Fresh pairing works over legacy HTTP after HTTPS negotiation falls back
- Client and server restarts reconnect normally
- Remote servers can be opened, launched, stopped, and restarted
- Remote configuration files can be downloaded, edited, uploaded, and reloaded
- Remote amscripts can be created, downloaded, edited, and saved
- Restricting a paired user disconnects it, and re-enabling access allows it to reconnect normally
- Pair requests can expire without throwing errors or leaving the headless listener enabled

Full TLS termination requires a reverse proxy and was not part of this local regression test; legacy HTTP fallback and the shared transport paths were verified.

Fixes #273

A special thanks to @Mathew005 for reporting and investigating the identity collisions that led to #273, and for their work with a suggested solution.