### PR TITLE
Add CurseForge support & Improve modpack integration

### DIFF
--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -2372,6 +2372,8 @@ def allow_close(allow: bool, banner=''):
     if banner and telepath_banner and app_config.telepath_settings['show-banners']:
         telepath_banner(banner, allow)
 
+    return True
+
 
 # Random splash message
 def generate_splash(crash=False):
@@ -2678,6 +2680,22 @@ def control_backspace(text, index):
 # Version agnostic starts with "semver"
 def is_semver(s: str):
     return bool(re.match(r'^((0|[1-9]\d*)(?:\.(0|[1-9]\d*))+|[1-9]\d*)(?![A-Za-z0-9])', s))
+
+
+# Converts a local file/object name into a reasonable Discovery search query
+def format_search_query(value):
+    value = os.path.basename(str(value or '')).strip()
+
+    # Remove known archive extensions
+    value = re.sub(r'\.(?:zip|mrpack|jar)$', '', value, flags=re.IGNORECASE)
+
+    # Remove auto-mcs duplicate-name suffixes
+    value = re.sub(r'\s+\(\d+\)$', '', value).strip()
+
+    # Remove provider packaging suffixes without trying to identify the project
+    value = re.sub(r'\s+(?:server|client)\s+(?:pack|files?)\b.*$', '', value, flags=re.IGNORECASE)
+    value = re.sub(r'\s+', ' ', value)
+    return value.strip(' .-_')
 
 
 # </editor-fold>

--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -59,7 +59,7 @@ text_logo = [
 app_title = "auto-mcs"
 app_version = "2.4"
 ams_version = "1.6.1"
-telepath_version = "1.3"
+telepath_version = "1.3.1"
 
 # Various project URLs for additional functionality within the app
 project_repo:           str = "https://github.com/macarooni-man/auto-mcs"
@@ -621,7 +621,7 @@ def create_archive(file_path: str, export_path: str, archive_type='tar') -> str 
 def move_files_root(source: str, destination: str = None):
     destination = source if not destination else destination
     folder_list = [d for d in glob(os.path.join(source, '*')) if os.path.isdir(d)]
-    file_list = [f for f in glob(os.path.join(source, '*')) if os.path.isdir(f)]
+    file_list = [f for f in glob(os.path.join(source, '*')) if os.path.isfile(f)]
     if len(folder_list) == 1 and len(file_list) <= 1:
 
         # Move data to root, and delete the sub-folder

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -1564,11 +1564,10 @@ class CurseForgeModpackProvider(ModpackProvider):
             if not mod.get('isAvailable', True):
                 continue
 
-            # If CurseForge provides latest files, only show projects with server packs
-            latest_files = mod.get('latestFiles') or []
-
-            if latest_files and not any(file.get('serverPackFileId') for file in latest_files):
-                continue
+            # If CurseForge provides latest files, only show projects in search results with server packs
+            # latest_files = mod.get('latestFiles') or []
+            # if latest_files and not any(file.get('serverPackFileId') for file in latest_files):
+            #     continue
 
             name = mod['name']
             author = (mod.get('authors') or [{}])[0].get('name', '')

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -1686,6 +1686,13 @@ class CurseForgeModpackProvider(ModpackProvider):
         online_modpack = ModpackWebObject(name, 'modpack', '', '', '', project_id, None)
         online_modpack.provider = self.name
 
+        # Restore project details needed by the update object
+        try:
+            project_data = constants.get_url(f'{self.project_api}{project_id}', return_response=True).json().get('data', {})
+            logo = project_data.get('logo') or {}
+            online_modpack.icon_url = logo.get('thumbnailUrl') or logo.get('url')
+        except: pass
+
         versions = self.get_modpack_versions(online_modpack)
 
         if not versions:
@@ -1870,6 +1877,13 @@ class ModrinthModpackProvider(ModpackProvider):
 
         if not online_modpack:
             return None
+
+        # Restore the project icon if the exact-ID path was used
+        if not getattr(online_modpack, 'icon_url', None):
+            try:
+                project_data = constants.get_url(f'https://api.modrinth.com/v2/project/{online_modpack.id}', return_response=True).json()
+                online_modpack.icon_url = project_data.get('icon_url')
+            except: pass
 
         versions = self.get_modpack_versions(online_modpack)
 

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -251,6 +251,10 @@ class Provider():
     def _stable_versions(versions):
         return [version for version in versions if is_semver(version) and "-" not in version]
 
+
+
+# Addons
+
 # Abstracts provider-specific network operations for downloadable items
 class AddonProvider(Provider):
 
@@ -1207,11 +1211,98 @@ class ModrinthProvider(AddonProvider):
         return addon_list
 
 
+
+# Modpacks
+
 # Abstracts provider-specific network operations for downloadable modpacks
 class ModpackProvider(Provider):
 
-    # Provider name
+    # Provider name / metadata
     name: str
+    metadata_name: str = None
+
+    # Normalizes a modpack version for display
+    @staticmethod
+    def _normalize_version(raw_version, game_versions=None, name=None, release_type=None):
+        version = str(raw_version or '').strip()
+
+        if not version:
+            return None
+
+        # Remove archive extension
+        version = re.sub(r'\.(?:zip|mrpack)$', '', version, flags=re.IGNORECASE).strip()
+        game_versions = {
+            str(game_version).strip().lower().lstrip('v')
+            for game_version in (game_versions or [])
+            if game_version
+        }
+
+        # Prefer version-like strings which aren't Minecraft versions
+        candidates = re.findall(r'(?<![A-Za-z0-9])v?\d+(?:\.\d+)+(?:[A-Za-z]+|[-+][A-Za-z][A-Za-z0-9.-]*)?', version, flags=re.IGNORECASE)
+        for candidate in reversed(candidates):
+            if candidate.lower().lstrip('v') not in game_versions:
+                return candidate
+
+        # Fall back to conservatively cleaning the provider label
+        cleaned = version
+
+        if name:
+            cleaned = re.sub(re.escape(str(name)), '', cleaned, flags=re.IGNORECASE)
+
+        for game_version in game_versions:
+            cleaned = re.sub(rf'(?<![\d.])v?{re.escape(game_version)}(?![\d.])', '', cleaned, flags=re.IGNORECASE)
+
+        if release_type:
+            cleaned = re.sub(rf'\b{re.escape(str(release_type))}\b', '', cleaned, flags=re.IGNORECASE)
+
+        cleaned = re.sub(r'\b(?:server(?:\s+pack|\s+files?)?|client)\b', '', cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r'\s*[-_|]+\s*', ' ', cleaned)
+        cleaned = re.sub(r'\s+', ' ', cleaned).strip(' .-_')
+
+        return cleaned or version
+
+    # Returns provider metadata for an installed modpack
+    def get_metadata(self, name: str):
+        if not self.metadata_name:
+            return None
+
+        file_name = self.metadata_name if constants.os_name == 'windows' else f'.{self.metadata_name}'
+        file_path = os.path.join(manager.server_path(name), file_name)
+
+        if not os.path.isfile(file_path):
+            return None
+
+        try:
+            with open(file_path, 'r', encoding='utf-8', errors='ignore') as file:
+                return json.load(file)
+
+        except:
+            return None
+
+    # Writes provider metadata to an extracted modpack
+    def write_metadata(self, metadata: dict, destination: str):
+        if not self.metadata_name or not metadata:
+            return False
+
+        with open(os.path.join(destination, self.metadata_name), 'w', encoding='utf-8') as file:
+            json.dump(metadata, file, indent=2)
+
+        return True
+
+    # Removes provider metadata from a modpack directory
+    def clear_metadata(self, destination: str):
+        if not self.metadata_name:
+            return
+
+        for file_name in [self.metadata_name, f'.{self.metadata_name}']:
+            file_path = os.path.join(destination, file_name)
+
+            if os.path.isfile(file_path):
+                if constants.os_name == 'windows':
+                    try: constants.run_proc(f'attrib -H "{file_path}"')
+                    except: pass
+
+                os.remove(file_path)
 
     # Returns list of modpack objects according to search
     # Query --> ModpackWebObject
@@ -1306,7 +1397,9 @@ class ModpackProvider(Provider):
                 modpack.download_url = latest.download_url
                 modpack.download_version = latest.download_version
                 modpack.addon_version = latest.addon_version
+                modpack.display_version = getattr(latest, 'display_version', latest.addon_version)
                 modpack.release_type = latest.release_type
+                modpack.metadata = getattr(latest, 'metadata', None)
 
                 return modpack
 
@@ -1317,11 +1410,18 @@ class ModpackProvider(Provider):
         cache_id = str(modpack.id or modpack.name).strip().lower()
         cache_hit, versions = self._get_cache('versions', cache_id)
 
-        if cache_hit:
-            return versions
+        if not cache_hit:
+            versions = self._get_modpack_versions(modpack)
+            self._set_cache('versions', versions, cache_id)
 
-        versions = self._get_modpack_versions(modpack)
-        self._set_cache('versions', versions, cache_id)
+        # Normalize human-facing versions without modifying provider identity
+        for version in versions or []:
+            version.display_version = self._normalize_version(
+                getattr(version, 'addon_version', None),
+                getattr(version, 'versions', None),
+                getattr(version, 'name', None),
+                getattr(version, 'release_type', None)
+            )
 
         return versions
 
@@ -1350,9 +1450,269 @@ class ModpackProvider(Provider):
         return constants.download_url(url, file_name, paths.downloads, hook)
 
 
+# Handles modpacks from the CurseForge API
+class CurseForgeModpackProvider(ModpackProvider):
+    name = 'curseforge'
+    metadata_name = 'curseforge.index.json'
+    project_url = 'https://www.curseforge.com/minecraft/modpacks/'
+    project_api = 'https://curseforge.auto-mcs.com/project/'
+
+    release_types = {
+        1: 'release',
+        2: 'beta',
+        3: 'alpha'
+    }
+
+    # CurseForge API responses should not be cached
+    def _get_cache(self, method: str, *args):
+        return False, None
+
+    def _set_cache(self, method: str, value, *args):
+        return value
+
+    # Cleans up CurseForge Minecraft versions
+    @staticmethod
+    def _format_game_version(raw_version):
+        if not isinstance(raw_version, str):
+            return None
+
+        match = re.search(r'\d+(?:\.\d+)+', raw_version)
+        return match.group(0) if match else None
+
+    # Grab every modpack from search result and return results dict
+    def search(self, query: str):
+        results = []
+        url = f'https://curseforge.auto-mcs.com/search?type=modpack&q={query}&page_size=50'
+        page_content = constants.get_url(url, return_response=True).json()
+
+        for mod in page_content.get('data', []):
+
+            if not mod.get('isAvailable', True):
+                continue
+
+            # If CurseForge provides latest files, only show projects with server packs
+            latest_files = mod.get('latestFiles') or []
+
+            if latest_files and not any(file.get('serverPackFileId') for file in latest_files):
+                continue
+
+            name = mod['name']
+            author = (mod.get('authors') or [{}])[0].get('name', '')
+            subtitle = str(mod.get('summary') or '').split("\n", 1)[0]
+            project_id = str(mod['id'])
+            link = (mod.get('links') or {}).get('websiteUrl') or self.project_url + mod['slug']
+            score = constants.similarity(query.strip().lower(), name.strip().lower())
+
+            if link:
+                modpack_obj = ModpackWebObject(name, 'modpack', author, subtitle, link, project_id, None)
+
+                logo = mod.get('logo') or {}
+                modpack_obj.icon_url = logo.get('thumbnailUrl') or logo.get('url')
+                modpack_obj.score = score
+
+                versions = []
+
+                for index in mod.get('latestFilesIndexes') or []:
+                    version = self._format_game_version(index.get('gameVersion'))
+
+                    if version and version not in versions:
+                        versions.append(version)
+
+                modpack_obj.versions = versions
+                results.append(modpack_obj)
+
+        return results
+
+    # Find modpack information
+    def get_description(self, modpack: ModpackWebObject):
+        file_link = f'{self.project_api}{modpack.id}/description'
+        return constants.get_url(file_link, return_response=True).json().get('data', '')
+
+    # Returns every available server-pack release as ModpackWebObjects
+    def _get_modpack_versions(self, modpack: ModpackWebObject):
+        modpack_list = []
+
+        # CurseForge allows up to 50 results per page
+        loop_limit   = 20
+        page_size    = 50
+        current_page = 0
+        total        = 0
+        retrieved    = -1
+
+        # Get data from the API per page
+        def get_content(page: int = 0):
+            page_url = f'{self.project_api}{modpack.id}/files?page_size={page_size}&index={page_size * page}'
+            return constants.get_url(page_url, return_response=True).json()
+
+        # Resolve server-pack files in bulk
+        def get_server_packs(files):
+            file_ids = [int(data['serverPackFileId']) for data in files if data.get('serverPackFileId')]
+
+            if not file_ids:
+                return {}
+
+            response = requests.post(
+                'https://curseforge.auto-mcs.com/files',
+                json = {'file_ids': list(dict.fromkeys(file_ids))},
+                timeout = 15
+            )
+            response.raise_for_status()
+
+            return {str(data['id']): data for data in response.json().get('data', [])}
+
+        # Process a single page
+        def process_page(page_content):
+            nonlocal retrieved, page_size, total, current_page
+
+            files      = page_content.get('data', [])
+            pagination = page_content.get('pagination', {})
+
+            if files:
+
+                # Learn server provided pagination on first load
+                if retrieved < 0:
+                    page_size = pagination.get('pageSize', page_size)
+                    total     = pagination.get('totalCount') or len(files)
+                    retrieved = 0
+
+                # Ensure the newest releases are processed first
+                files.sort(key=lambda data: data.get('fileDate', ''), reverse=True)
+
+                # Only resolve files which actually have a dedicated server pack
+                server_files = get_server_packs(files)
+
+                # Create a ModpackWebObject for every server-pack release
+                for data in files:
+                    server_pack_id = data.get('serverPackFileId')
+
+                    if not server_pack_id or not data.get('isAvailable', True):
+                        continue
+
+                    server_file = server_files.get(str(server_pack_id))
+
+                    if not server_file or not server_file.get('isAvailable', True):
+                        continue
+
+                    # Never fall back to a normal/client CurseForge archive
+                    if not server_file.get('isServerPack', False):
+                        continue
+
+                    download_url = server_file.get('downloadUrl')
+
+                    # Respect projects/files which disable third-party distribution
+                    if not download_url:
+                        continue
+
+                    versions = []
+
+                    for version in data.get('gameVersions', []):
+                        version = self._format_game_version(version)
+
+                        if version and version not in versions:
+                            versions.append(version)
+
+                    # Fall back to the server file's metadata if necessary
+                    if not versions:
+                        for version in server_file.get('gameVersions', []):
+                            version = self._format_game_version(version)
+
+                            if version and version not in versions:
+                                versions.append(version)
+
+                    if not versions:
+                        continue
+
+                    new_modpack = deepcopy(modpack)
+                    new_modpack.versions = versions
+                    new_modpack.download_url = download_url
+
+                    # Store the main CurseForge release ID, NOT the server-pack file ID
+                    new_modpack.download_version = str(data['id'])
+                    new_modpack.addon_version = (data.get('displayName') or data.get('fileName') or str(data['id']))
+                    new_modpack.release_type = self.release_types.get(data.get('releaseType'))
+                    new_modpack.metadata = {
+                        'projectId': str(modpack.id),
+                        'fileId': str(data['id']),
+                        'serverPackFileId': str(server_pack_id)
+                    }
+
+                    modpack_list.append(new_modpack)
+
+                retrieved += len(files)
+                current_page += 1
+
+            # Stop on no results
+            else:
+                raise StopIteration
+
+
+        # First page sync to learn pagination
+        try:
+            first_page = get_content(current_page)
+            process_page(first_page)
+        except StopIteration:
+            pass
+
+        # Load remaining pages via thread pool merged in order
+        if 0 <= retrieved < total and current_page < loop_limit:
+            num_pages = math.ceil(total / page_size) if page_size else 0
+            last_page = min(loop_limit, num_pages)
+
+            if last_page > current_page:
+                pages = range(current_page, last_page)
+
+                with ThreadPoolExecutor(max_workers=2) as pool:
+                    for page_content in pool.map(get_content, pages):
+                        try: process_page(page_content)
+                        except StopIteration:
+                            break
+
+        return modpack_list
+
+    # Checks if an installed CurseForge pack has an update
+    def check_update(self, name: str):
+        metadata = self.get_metadata(name)
+
+        if not metadata:
+            return None
+
+        project_id = str(metadata.get('projectId') or '')
+        current_id = str(metadata.get('fileId') or '')
+
+        if not project_id or not current_id:
+            return None
+
+        # Reconstruct the provider project from persistent metadata
+        online_modpack = ModpackWebObject(name, 'modpack', '', '', '', project_id, None)
+        online_modpack.provider = self.name
+
+        versions = self.get_modpack_versions(online_modpack)
+
+        if not versions:
+            return None
+
+        # Ensure the installed CurseForge release still exists
+        current = next((modpack for modpack in versions if str(modpack.download_version) == current_id), None)
+
+        # Never invent an update when the installed release can't be identified
+        if not current:
+            return None
+
+        # _get_modpack_versions() returns newest releases first
+        latest = next((modpack for modpack in versions if modpack.download_url), None)
+        if not latest:
+            return None
+
+        if str(current.download_version) != str(latest.download_version):
+            return latest
+
+        return None
+
+
 # Handles modpacks from the Modrinth API
 class ModrinthModpackProvider(ModpackProvider):
     name = 'modrinth'
+    metadata_name = 'modrinth.index.json'
 
     # Returns the provider version ID for a local .mrpack
     def get_file_version(self, file_path: str):
@@ -1543,28 +1903,26 @@ class ModrinthModpackProvider(ModpackProvider):
         return None
 
 
-# Map for providers per server type
-addon_provider_registry = {
-    'vanilla':     [],
 
-    'craftbukkit': [HangarProvider, ModrinthProvider, CurseForgeProvider],
-    'spigot':      [HangarProvider, ModrinthProvider, CurseForgeProvider],
-    'paper':       [HangarProvider, ModrinthProvider, CurseForgeProvider],
-    'purpur':      [HangarProvider, ModrinthProvider, CurseForgeProvider],
-
-    'forge':       [ModrinthProvider, CurseForgeProvider],
-    'neoforge':    [ModrinthProvider, CurseForgeProvider],
-    'fabric':      [ModrinthProvider, CurseForgeProvider],
-    'quilt':       [ModrinthProvider, CurseForgeProvider]
-}
-
-# Default modpack provider for backwards-compatible module functions
-modpack_provider = ModrinthModpackProvider()
-
-
+# ---------------------------------------------- Manager Singletons ----------------------------------------------------
 
 # Server addon manager object for ServerManager()
 class AddonManager():
+
+    # Map for providers per server type
+    provider_registry = {
+        'vanilla': [],
+
+        'craftbukkit': [HangarProvider, ModrinthProvider, CurseForgeProvider],
+        'spigot':      [HangarProvider, ModrinthProvider, CurseForgeProvider],
+        'paper':       [HangarProvider, ModrinthProvider, CurseForgeProvider],
+        'purpur':      [HangarProvider, ModrinthProvider, CurseForgeProvider],
+
+        'forge':       [ModrinthProvider, CurseForgeProvider],
+        'neoforge':    [ModrinthProvider, CurseForgeProvider],
+        'fabric':      [ModrinthProvider, CurseForgeProvider],
+        'quilt':       [ModrinthProvider, CurseForgeProvider]
+    }
 
     def _to_json(self):
         final_data = {
@@ -1573,6 +1931,7 @@ class AddonManager():
             if not (k.endswith('__') or callable(getattr(self, k)))
         }
 
+        final_data.pop('provider_registry', None)
         final_data.pop('_providers', None)
         final_data.pop('_update_lock', None)
 
@@ -1644,7 +2003,7 @@ class AddonManager():
     def _set_providers(self, server_properties=None):
         server_properties = server_properties or self._server
         server_type = str(server_properties.get('type') or '').lower()
-        provider_list = addon_provider_registry.get(server_type, [])
+        provider_list = self.provider_registry.get(server_type, [])
         loaded_list = [provider.__class__ for provider in self._providers.values()]
 
         # Recreate the registry only when the available providers change
@@ -2450,6 +2809,141 @@ class AddonManager():
                 if 'geyser' in addon.id.lower(): return True
 
         return False
+
+
+# Routes modpack actions across available providers
+class ModpackManager():
+
+    # Map for available modpack providers
+    provider_registry = [
+        ModrinthModpackProvider,
+        CurseForgeModpackProvider
+    ]
+
+    # Internal log wrapper
+    def _send_log(self, message: str, level: str = None):
+        return send_log(self.__class__.__name__, message, level)
+
+    def __init__(self):
+        self._providers = {}
+
+        for provider_class in self.provider_registry:
+            provider = provider_class()
+            self._providers[provider.name] = provider
+
+        self._send_log(f"loaded modpack providers: {list(self._providers)}")
+
+    # Runs a modpack method across all providers
+    def _run_providers(self, method, *args, **kwargs):
+        modpack = args[0] if args else None
+
+        # Route provider-specific web objects directly
+        if isinstance(modpack, ModpackWebObject):
+            provider = self._providers.get(getattr(modpack, 'provider', None))
+
+            if not provider:
+                return []
+
+            return getattr(provider, method)(*args, **kwargs)
+
+        providers = list(self._providers.values())
+
+        if not providers:
+            return []
+
+        def run(provider):
+            try: return getattr(provider, method)(*args, **kwargs)
+            except Exception as e:
+                self._send_log(f"provider '{provider.name}' failed to run '{method}': {constants.format_traceback(e)}", 'error')
+
+        with ThreadPoolExecutor(max_workers=len(providers)) as pool:
+            result_list = list(pool.map(run, providers))
+
+        modpack_list = []
+
+        for result in result_list:
+            if isinstance(result, list):
+                modpack_list.extend(result)
+
+            elif result:
+                modpack_list.append(result)
+
+        return modpack_list
+
+    # Returns metadata file names for registered providers
+    def get_metadata_names(self):
+        return [provider.metadata_name for provider in self._providers.values() if provider.metadata_name]
+
+    def clear_metadata(self, destination: str):
+        for provider in self._providers.values():
+            provider.clear_metadata(destination)
+
+    # Searches all modpack providers concurrently
+    def search_modpacks(self, query: str, _log: bool = True):
+        if _log: self._send_log(f"searching for '{query.strip()}'...", 'info')
+
+        results = self._run_providers('search_modpacks', query, _log=False)
+        results = sorted(results, key=lambda modpack: getattr(modpack, 'score', 0), reverse=True)
+
+        if _log: self._send_log(f"found {len(results)} modpack(s) for '{query.strip()}'", 'info')
+        return results
+
+    # Returns advanced information from the originating provider
+    def get_modpack_info(self, modpack: ModpackWebObject):
+        return self._run_providers('get_modpack_info', modpack)
+
+    # Returns the latest available release from the originating provider
+    def get_modpack_url(self, modpack: ModpackWebObject):
+        return self._run_providers('get_modpack_url', modpack)
+
+    # Returns every release from the originating provider
+    def get_modpack_versions(self, modpack: ModpackWebObject):
+        return self._run_providers('get_modpack_versions', modpack)
+
+    # Returns the provider by name
+    def get_provider(self, provider_name: str):
+        return self._providers.get(str(provider_name or '').lower())
+
+    # Returns the provider which owns an installed modpack
+    def get_server_provider(self, name: str):
+        providers = [
+            provider for provider in self._providers.values()
+            if provider.get_metadata(name)
+        ]
+
+        # Never guess if conflicting metadata exists
+        return providers[0] if len(providers) == 1 else None
+
+    # Resolves the provider for an installed modpack
+    def resolve_server(self, name: str):
+        provider = self.get_server_provider(name)
+        return provider.name if provider else 'unknown'
+
+    # Checks an installed modpack for updates
+    def check_for_updates(self, name: str):
+        provider = self.get_server_provider(name)
+
+        if provider:
+            update = provider.check_for_updates(name)
+
+            if update:
+                update.provider = provider.name
+
+            return update
+
+        return None
+
+    # Downloads a modpack archive
+    def download_modpack(self, name: str, url: str, progress_func=None):
+        def hook(a, b, c):
+            if progress_func:
+                progress_func(round(100 * a * b / c))
+
+        file_name = f"{constants.sanitize_name(name)}.{url.rsplit('.', 1)[-1]}"
+        return constants.download_url(url, file_name, paths.downloads, hook)
+
+# Global modpack manager singleton
+modpack_manager = ModpackManager()
 
 
 
@@ -3266,29 +3760,29 @@ def is_geyser_addon(addon):
 # Returns list of modpack objects according to search
 # Query --> ModpackWebObject
 def search_modpacks(query: str, _log: bool = True, *a):
-    return modpack_provider.search_modpacks(query, _log, *a)
+    return modpack_manager.search_modpacks(query, _log, *a)
 
 # Returns advanced addon object properties
 # ModpackWebObject
 def get_modpack_info(modpack: ModpackWebObject, *a):
-    return modpack_provider.get_modpack_info(modpack, *a)
+    return modpack_manager.get_modpack_info(modpack, *a)
 
 # Return the latest available supported download link
 # ModpackWebObject
 def get_modpack_url(modpack: ModpackWebObject, *a):
-    return modpack_provider.get_modpack_url(modpack, *a)
+    return modpack_manager.get_modpack_url(modpack, *a)
 
 # Returns every available modpack release
 def get_modpack_versions(modpack: ModpackWebObject, *a):
-    return modpack_provider.get_modpack_versions(modpack, *a)
+    return modpack_manager.get_modpack_versions(modpack, *a)
 
 # Checks for available modpack updates
 def check_modpack_updates(name: str):
-    return modpack_provider.check_for_updates(name)
+    return modpack_manager.check_for_updates(name)
 
-# Downloads a modpack archive from the current provider
+# Downloads a modpack archive
 def download_modpack(name: str, url: str, progress_func=None):
-    return modpack_provider.download_modpack(name, url, progress_func)
+    return modpack_manager.download_modpack(name, url, progress_func)
 
 
 

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -683,6 +683,272 @@ class AddonProvider(Provider):
         return False
 
 
+# Handles mods/plugins from the CurseForge API
+class CurseForgeProvider(AddonProvider):
+    name = 'curseforge'
+    project_url = 'https://www.curseforge.com/minecraft/mc-mods/'
+    project_api = 'https://curseforge.auto-mcs.com/project/'
+
+    loader_types = {
+        'forge':    1,
+        'fabric':   4,
+        'quilt':    5,
+        'neoforge': 6
+    }
+
+    release_types = {
+        1: 'release',
+        2: 'beta',
+        3: 'alpha'
+    }
+
+    def __init__(self, server_properties: dict):
+        super().__init__(server_properties)
+
+        if self.server_type == 'bukkit':
+            self.project_url = 'https://www.curseforge.com/minecraft/bukkit-plugins/'
+
+    # CurseForge API responses should not be cached
+    def _get_cache(self, method: str, *args):
+        return False, None
+
+    def _set_cache(self, method: str, value, *args):
+        return value
+
+    # Internal helper to convert server type into search filters
+    def _get_loader_types(self):
+        if self.server_type == 'bukkit':
+            return []
+
+        if self.server_type == 'quilt':
+            return ['quilt', 'fabric']
+
+        return [self.server_type]
+
+    # Cleans up CurseForge Minecraft versions
+    @staticmethod
+    def _format_game_version(raw_version):
+        if not isinstance(raw_version, str):
+            return None
+
+        match = re.search(r'\d+(?:\.\d+)+', raw_version)
+        return match.group(0) if match else None
+
+    # Extracts the add-on version without confusing it with the Minecraft version
+    @staticmethod
+    def _format_addon_version(data, game_versions):
+        raw_version = str(data.get('displayName') or data.get('fileName') or '')
+        version_list = re.findall(r'\d+(?:\.\d+)+', raw_version)
+
+        if not version_list:
+            return None
+
+        # Prefer a version which isn't just the supported Minecraft version
+        for version in version_list:
+            if version not in game_versions:
+                return version
+
+        # Some older projects use the Minecraft version as their own release version
+        return version_list[0]
+
+    # Grab every add-on from search result and return results dict
+    def search(self, query: str):
+        results = []
+        addon_type = 'plugin' if self.server_type == 'bukkit' else 'mod'
+        search_url = self.project_url
+
+        url = f'https://curseforge.auto-mcs.com/search?type={addon_type}&q={query}&page_size=50'
+        page_content = constants.get_url(url, return_response=True).json()
+
+        loader_ids = [
+            self.loader_types[loader]
+            for loader in self._get_loader_types()
+            if loader in self.loader_types
+        ]
+
+        for mod in page_content.get('data', []):
+
+            if not mod.get('isAvailable', True):
+                continue
+
+            indexes = mod.get('latestFilesIndexes') or []
+
+            # Filter projects which have no releases for this loader
+            if loader_ids and indexes:
+                loader_indexes = [
+                    index for index in indexes
+                    if index.get('modLoader') in loader_ids
+                ]
+
+                if not loader_indexes:
+                    continue
+
+            else:
+                loader_indexes = indexes
+
+            name = mod['name']
+            author = (mod.get('authors') or [{}])[0].get('name', '')
+            subtitle = str(mod.get('summary') or '').split("\n", 1)[0]
+            file_name = mod['slug']
+            link = (mod.get('links') or {}).get('websiteUrl') or search_url + file_name
+            project_id = str(mod['id'])
+
+            if link:
+                addon_obj = AddonWebObject(name, self.server_type, author, subtitle, link, project_id, None)
+
+                logo = mod.get('logo') or {}
+                addon_obj.icon_url = logo.get('thumbnailUrl') or logo.get('url')
+
+                versions = []
+                for index in loader_indexes:
+                    version = self._format_game_version(index.get('gameVersion'))
+
+                    if version and version not in versions:
+                        versions.append(version)
+
+                addon_obj.versions = versions
+                results.append(addon_obj)
+
+        return results
+
+    # Run specific actions for CurseForge mods/plugins
+    def get_description(self, addon: AddonWebObject):
+
+        # Find add-on information
+        file_link = f'{self.project_api}{addon.id}/description'
+        page_content = constants.get_url(file_link, return_response=True).json()
+        return page_content.get('data', '')
+
+    # Returns every available CurseForge release as AddonWebObjects
+    def _get_addon_versions(self, addon: AddonWebObject, server_version=None, latest=False):
+        addon_list = []
+
+        # CurseForge allows up to 50 results per page
+        loop_limit   = 20
+        page_size    = 50
+        current_page = 0
+        total        = 0
+        retrieved    = -1
+
+        loader_types = self._get_loader_types()
+        loader_type = loader_types[0] if loader_types else None
+
+        # Get data from the API per page
+        def get_content(page: int = 0, loader=None):
+            if loader is None:
+                loader = loader_type
+
+            page_url = f'{self.project_api}{addon.id}/files?page_size={page_size}&index={page_size * page}'
+
+            if server_version:
+                page_url += f'&version={server_version}'
+
+            if loader:
+                page_url += f'&loader={loader}'
+
+            return constants.get_url(page_url, return_response=True).json()
+
+        # Process a single page
+        def process_page(page_content):
+            nonlocal retrieved, page_size, total, current_page
+
+            files      = page_content.get('data', [])
+            pagination = page_content.get('pagination', {})
+
+            if files:
+
+                # Learn server provided pagination on first load
+                if retrieved < 0:
+                    page_size = pagination.get('pageSize', page_size)
+                    total     = pagination.get('totalCount') or len(files)
+                    retrieved = 0
+
+                # Ensure the newest releases are processed first
+                files.sort(key=lambda data: data.get('fileDate', ''), reverse=True)
+
+                # Create an AddonWebObject for every release
+                for data in files:
+
+                    if not data.get('isAvailable', True):
+                        continue
+
+                    download_url = data.get('downloadUrl')
+
+                    # Respect projects/files which disable third-party distribution
+                    if not download_url:
+                        continue
+
+                    versions = []
+
+                    for version in data.get('gameVersions', []):
+                        version = self._format_game_version(version)
+
+                        if version and version not in versions:
+                            versions.append(version)
+
+                    if not versions:
+                        continue
+
+                    addon_version = self._format_addon_version(data, versions)
+
+                    new_addon = deepcopy(addon)
+                    new_addon.versions = versions
+                    new_addon.download_url = download_url
+                    new_addon.download_version = None
+                    new_addon.addon_version = addon_version
+                    new_addon.release_type = self.release_types.get(data.get('releaseType'))
+
+                    addon_list.append(new_addon)
+
+                retrieved += len(files)
+                current_page += 1
+
+            # Stop on no results
+            else:
+                raise StopIteration
+
+
+        # First page sync to learn pagination
+        try:
+            first_page = get_content(current_page)
+            process_page(first_page)
+        except StopIteration:
+            pass
+
+        # Quilt can generally use Fabric mods as a fallback
+        if not addon_list and self.server_type == 'quilt':
+            loader_type = 'fabric'
+            current_page = 0
+            total = 0
+            retrieved = -1
+
+            try:
+                first_page = get_content(current_page, loader_type)
+                process_page(first_page)
+            except StopIteration:
+                pass
+
+        # Update lookups only need the newest supported release
+        if latest:
+            return addon_list[:1]
+
+        # Load remaining pages via thread pool merged in order
+        if 0 <= retrieved < total and current_page < loop_limit:
+            num_pages = math.ceil(total / page_size) if page_size else 0
+            last_page = min(loop_limit, num_pages)
+
+            if last_page > current_page:
+                pages = range(current_page, last_page)
+
+                with ThreadPoolExecutor(max_workers=2) as pool:
+                    for page_content in pool.map(get_content, pages):
+                        try: process_page(page_content)
+                        except StopIteration:
+                            break
+
+        return addon_list
+
+
 # Handles plugins from the Hangar API
 class HangarProvider(AddonProvider):
     name = 'hangar'
@@ -1281,15 +1547,15 @@ class ModrinthModpackProvider(ModpackProvider):
 addon_provider_registry = {
     'vanilla':     [],
 
-    'craftbukkit': [HangarProvider, ModrinthProvider],
-    'spigot':      [HangarProvider, ModrinthProvider],
-    'paper':       [HangarProvider, ModrinthProvider],
-    'purpur':      [HangarProvider, ModrinthProvider],
+    'craftbukkit': [HangarProvider, ModrinthProvider, CurseForgeProvider],
+    'spigot':      [HangarProvider, ModrinthProvider, CurseForgeProvider],
+    'paper':       [HangarProvider, ModrinthProvider, CurseForgeProvider],
+    'purpur':      [HangarProvider, ModrinthProvider, CurseForgeProvider],
 
-    'forge':       [ModrinthProvider],
-    'neoforge':    [ModrinthProvider],
-    'fabric':      [ModrinthProvider],
-    'quilt':       [ModrinthProvider]
+    'forge':       [ModrinthProvider, CurseForgeProvider],
+    'neoforge':    [ModrinthProvider, CurseForgeProvider],
+    'fabric':      [ModrinthProvider, CurseForgeProvider],
+    'quilt':       [ModrinthProvider, CurseForgeProvider]
 }
 
 # Default modpack provider for backwards-compatible module functions

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -1463,6 +1463,13 @@ class CurseForgeModpackProvider(ModpackProvider):
         3: 'alpha'
     }
 
+    loader_types = {
+        1: 'forge',
+        4: 'fabric',
+        5: 'quilt',
+        6: 'neoforge'
+    }
+
     # CurseForge API responses should not be cached
     def _get_cache(self, method: str, *args):
         return False, None
@@ -1511,14 +1518,26 @@ class CurseForgeModpackProvider(ModpackProvider):
                 modpack_obj.score = score
 
                 versions = []
+                loaders = []
+                loader_map = {}
 
                 for index in mod.get('latestFilesIndexes') or []:
                     version = self._format_game_version(index.get('gameVersion'))
+                    loader = self.loader_types.get(index.get('modLoader'))
 
                     if version and version not in versions:
                         versions.append(version)
 
+                    if loader:
+                        if loader not in loaders:
+                            loaders.append(loader)
+
+                        if index.get('fileId'):
+                            loader_map[str(index['fileId'])] = loader
+
                 modpack_obj.versions = versions
+                modpack_obj.loaders = loaders
+                modpack_obj.loader_map = loader_map
                 results.append(modpack_obj)
 
         return results
@@ -1604,7 +1623,6 @@ class CurseForgeModpackProvider(ModpackProvider):
                         continue
 
                     versions = []
-
                     for version in data.get('gameVersions', []):
                         version = self._format_game_version(version)
 
@@ -1622,8 +1640,21 @@ class CurseForgeModpackProvider(ModpackProvider):
                     if not versions:
                         continue
 
+
+                    loaders = []
+
+                    # Use the exact file loader when CurseForge indexed this release
+                    loader = (getattr(modpack, 'loader_map', {}) or {}).get(str(data['id']))
+                    if loader:
+                        loaders.append(loader)
+
+                    # Otherwise inherit the project loader when it's unambiguous
+                    elif len(getattr(modpack, 'loaders', None) or []) == 1:
+                        loaders = list(modpack.loaders)
+
                     new_modpack = deepcopy(modpack)
                     new_modpack.versions = versions
+                    new_modpack.loaders = loaders
                     new_modpack.download_url = download_url
 
                     # Store the main CurseForge release ID, NOT the server-pack file ID
@@ -1810,6 +1841,10 @@ class ModrinthModpackProvider(ModpackProvider):
 
             new_modpack = deepcopy(modpack)
             new_modpack.versions = data.get('game_versions', [])
+            new_modpack.loaders = [
+                str(loader).strip().lower() for loader in data.get('loaders', [])
+                if str(loader).strip()
+            ]
             new_modpack.download_url = file['url']
             new_modpack.download_version = data['id']
             new_modpack.addon_version = data['version_number']

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -1486,6 +1486,25 @@ class CurseForgeModpackProvider(ModpackProvider):
         match = re.search(r'\d+(?:\.\d+)+', raw_version)
         return match.group(0) if match else None
 
+    # Resolves CurseForge file IDs in bulk
+    def get_files(self, file_ids):
+        file_ids = list(dict.fromkeys([int(file_id) for file_id in file_ids if str(file_id).isdigit()]))
+        if not file_ids:
+            return {}
+
+        files = []
+
+        # CurseForge accepts file IDs in batches
+        for index in range(0, len(file_ids), 50):
+            response = requests.post('https://curseforge.auto-mcs.com/files', json={'file_ids': file_ids[index:index + 50]}, timeout=15)
+            response.raise_for_status()
+            files.extend(response.json().get('data', []))
+
+        return {
+            str(data['id']): data for data in files
+            if data.get('id') is not None
+        }
+
     # Resolves an imported CurseForge manifest to persistent provider metadata
     def get_import_metadata(self, manifest: dict):
         if not isinstance(manifest, dict):
@@ -1611,22 +1630,6 @@ class CurseForgeModpackProvider(ModpackProvider):
             page_url = f'{self.project_api}{modpack.id}/files?page_size={page_size}&index={page_size * page}'
             return constants.get_url(page_url, return_response=True).json()
 
-        # Resolve server-pack files in bulk
-        def get_server_packs(files):
-            file_ids = [int(data['serverPackFileId']) for data in files if data.get('serverPackFileId')]
-
-            if not file_ids:
-                return {}
-
-            response = requests.post(
-                'https://curseforge.auto-mcs.com/files',
-                json = {'file_ids': list(dict.fromkeys(file_ids))},
-                timeout = 15
-            )
-            response.raise_for_status()
-
-            return {str(data['id']): data for data in response.json().get('data', [])}
-
         # Process a single page
         def process_page(page_content):
             nonlocal retrieved, page_size, total, current_page
@@ -1646,7 +1649,7 @@ class CurseForgeModpackProvider(ModpackProvider):
                 files.sort(key=lambda data: data.get('fileDate', ''), reverse=True)
 
                 # Only resolve files which actually have a dedicated server pack
-                server_files = get_server_packs(files)
+                server_files = self.get_files([data['serverPackFileId'] for data in files if data.get('serverPackFileId')])
 
                 # Create a ModpackWebObject for every server-pack release
                 for data in files:

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -1486,6 +1486,54 @@ class CurseForgeModpackProvider(ModpackProvider):
         match = re.search(r'\d+(?:\.\d+)+', raw_version)
         return match.group(0) if match else None
 
+    # Resolves an imported CurseForge manifest to persistent provider metadata
+    def get_import_metadata(self, manifest: dict):
+        if not isinstance(manifest, dict):
+            return None
+
+        project_id = manifest.get('projectID')
+        pack_version = manifest.get('version')
+        pack_name = manifest.get('name')
+        game_version = (manifest.get('minecraft') or {}).get('version')
+
+        if not project_id or not pack_version:
+            return None
+
+        project_id = str(project_id)
+
+        # Reconstruct the project using the identity embedded in the manifest
+        modpack = ModpackWebObject(pack_name or '', 'modpack', '', '', '', project_id, None)
+        modpack.provider = self.name
+        releases = self.get_modpack_versions(modpack)
+        if not releases:
+            return None
+
+        # Normalize the manifest's version the same way
+        target_version = self._normalize_version(pack_version, [game_version] if game_version else [], pack_name)
+        if not target_version:
+            return None
+
+        def version_key(version):
+            return str(version or '').strip().lower().lstrip('v')
+
+        target_key = version_key(target_version)
+
+        matches = []
+        for release in releases:
+
+            # Preserve Minecraft-version identity when the manifest provides it
+            if game_version and str(game_version) not in [str(version) for version in release.versions]:
+                continue
+
+            if version_key(getattr(release, 'display_version', None) or release.addon_version) == target_key:
+                matches.append(release)
+
+        # Never guess between multiple matching CurseForge releases
+        if len(matches) != 1:
+            return None
+
+        return getattr(matches[0], 'metadata', None)
+
     # Grab every modpack from search result and return results dict
     def search(self, query: str):
         results = []

--- a/source/core/server/foundry.py
+++ b/source/core/server/foundry.py
@@ -2547,6 +2547,7 @@ def scan_modpack(update=False, progress_func=None):
 
     test_server = os.path.join(paths.temp, 'importtest')
     send_log('scan_modpack', f"extracting '{file_path}' to '{test_server}'...", 'info')
+    safe_delete(test_server)
     folder_check(test_server)
     os.chdir(test_server)
 
@@ -2629,32 +2630,14 @@ def scan_modpack(update=False, progress_func=None):
             with open(mr_index, 'r', encoding='utf-8', errors='ignore') as f:
                 modrinth_data = json.loads(f.read())
 
-            # Reject absolute paths & ensure the final path remains inside test_server
-            def validate_path(path):
-                path = path.replace('\\', '/')
-
-                if os.path.isabs(path) or ntpath.isabs(path) or ntpath.splitdrive(path)[0]:
-                    raise RuntimeWarning(f"This modpack is potentially malicious! use of an invalid absolute path: '{path}'")
-
-                destination_path = os.path.realpath(os.path.join(test_server, path))
-                test_path = os.path.realpath(test_server)
-
-                if os.path.commonpath([test_path, destination_path]) != test_path:
-                    raise RuntimeWarning(f"This modpack is potentially malicious! path escapes modpack directory: '{path}'")
-
-                return destination_path
-
-            # Reorganize .json for ease of iteration
-            metadata = []
             try:
                 if mr_version:
                     modrinth_data['modrinthVersionId'] = mr_version
+
                     with open(mr_index, 'w', encoding='utf-8') as f:
                         f.write(json.dumps(modrinth_data, indent=2))
 
-                modrinth_files = modrinth_data["files"]
                 dependencies = modrinth_data['dependencies']
-
                 data['name'] = import_data['name'] if update else modrinth_data.get('name')
                 data['version'] = dependencies['minecraft']
 
@@ -2666,67 +2649,12 @@ def scan_modpack(update=False, progress_func=None):
                         data['build'] = build
                         break
 
-                for i in modrinth_files:
-
-                    # Skip client-side only mods
-                    # Dependencies don't seem to be tagged properly
-                    if i.get('env', {}).get('server', None) != 'required':
-                        continue
-
-                    trusted_sources = ('cdn.modrinth.com',)
-                    for download_link in i['downloads']:
-                        parsed_url = urlparse(download_link)
-
-                        if (
-                            parsed_url.scheme != 'https'
-                            or parsed_url.hostname not in trusted_sources
-                            or parsed_url.port not in (None, 443)
-                        ):
-                            raise RuntimeWarning(f"This modpack is potentially malicious! URL escapes Modrinth's site: '{download_link}'")
-
-                    destination = validate_path(i['path'])
-                    metadata.append({
-                        'urls': i['downloads'],
-                        'hash': i['hashes']['sha512'],
-                        'file_name': os.path.basename(destination),
-                        'destination': os.path.dirname(destination)
-                    })
-
             except (KeyError, IndexError, TypeError, ValueError) as e:
                 send_log('scan_modpack', f'Failed to parse Modrinth pack: {format_traceback(e)}', 'warning')
                 return False
 
-            def get_mod_url(mod_data):
-                file_path = os.path.join(mod_data['destination'], mod_data['file_name'])
-                for url in mod_data['urls']:
-                    try:
-                        if not cs_download_url(url, mod_data['file_name'], mod_data['destination']):
-                            continue
-
-                        # Validate that the downloaded mod is the same one in the index
-                        file_hash = hashlib.sha512()
-                        with open(file_path, 'rb') as file:
-                            for chunk in iter(lambda: file.read(1048576), b''):
-                                file_hash.update(chunk)
-
-                        if file_hash.hexdigest().lower() == mod_data['hash'].lower():
-                            return True
-
-                        os.remove(file_path)
-
-                    except Exception:
-                        continue
-
-                send_log('scan_modpack', f"failed to validate '{mod_data['file_name']}'", 'warning')
-                return False
-
-            # Iterate over additional content to see if it's available to be downloaded
-            with ThreadPoolExecutor(max_workers=20) as pool:
-                for result in pool.map(get_mod_url, metadata):
-                    if not result: return result
-
             pack_provider = 'modrinth'
-            send_log('scan_modpack', f"determined modpack type 'Modrinth'", 'info')
+            send_log('scan_modpack', "determined modpack type 'Modrinth'", 'info')
 
 
     # Approach #2: Look for CurseForge "manifest.json"
@@ -2745,6 +2673,33 @@ def scan_modpack(update=False, progress_func=None):
                 if curseforge_data.get('manifestType') == 'minecraftModpack':
                     client_pack_name = curseforge_data.get('name')
 
+                    # Determine server metadata directly from the CurseForge manifest
+                    minecraft = curseforge_data.get('minecraft') or {}
+                    mod_loaders = minecraft.get('modLoaders') or []
+
+                    if update:
+                        data['name'] = import_data['name']
+                    elif curseforge_data.get('name'):
+                        data['name'] = curseforge_data['name']
+
+                    if minecraft.get('version'):
+                        data['version'] = minecraft['version']
+
+                    primary_loader = next(
+                        (loader for loader in mod_loaders if loader.get('primary')),
+                        mod_loaders[0] if mod_loaders else None
+                    )
+
+                    if primary_loader:
+                        loader_id = str(primary_loader.get('id') or '')
+                        loader_type, _, loader_build = loader_id.partition('-')
+                        loader_type = loader_type.lower().strip()
+
+                        if loader_type in ['forge', 'neoforge', 'fabric', 'quilt']:
+                            data['type'] = loader_type
+                            data['build'] = loader_build
+
+                    # Preserve published provider metadata when it can be resolved
                     cf_provider = addons.modpack_manager.get_provider('curseforge')
                     cf_metadata = cf_provider.get_import_metadata(curseforge_data)
 
@@ -3098,6 +3053,273 @@ def scan_modpack(update=False, progress_func=None):
         log_content = f"unable to determine all the required metadata:\n'data': {data}"
         send_log('scan_modpack', log_content, 'error')
         return False
+
+
+# Downloads content referenced by supported modpack manifests
+def download_modpack_files(update=False, progress_func=None):
+    global import_data
+
+    telepath_data = None
+
+    if constants.server_manager.current_server and update:
+        telepath_data = constants.server_manager.current_server._telepath_data
+
+    try:
+        if not telepath_data and new_server_info['_telepath_data']:
+            telepath_data = new_server_info['_telepath_data']
+    except KeyError:
+        pass
+
+    # Execute remotely for Telepath imports/updates
+    if telepath_data:
+        response = constants.api_manager.request(
+            endpoint = '/create/download_modpack_files',
+            host = telepath_data['host'],
+            port = telepath_data['port'],
+            args = {'update': update}
+        )
+
+        if progress_func and response:
+            progress_func(100)
+
+        return response
+
+
+    test_server = os.path.join(paths.temp, 'importtest')
+    if not os.path.isdir(test_server):
+        return False
+
+
+    # Reject absolute paths & ensure the final path remains inside test_server
+    def validate_path(path):
+        path = str(path or '').replace('\\', '/')
+
+        if os.path.isabs(path) or ntpath.isabs(path) or ntpath.splitdrive(path)[0]:
+            raise RuntimeWarning(f"This modpack is potentially malicious! use of an invalid absolute path: '{path}'")
+
+        destination_path = os.path.realpath(os.path.join(test_server, path))
+        test_path = os.path.realpath(test_server)
+
+        if os.path.commonpath([test_path, destination_path]) != test_path:
+            raise RuntimeWarning(f"This modpack is potentially malicious! path escapes modpack directory: '{path}'")
+
+        return destination_path
+
+
+    # Restrict downloads to trusted provider sources
+    def validate_url(url, trusted_sources, allow_subdomains=False):
+        parsed_url = urlparse(str(url or ''))
+        hostname = str(parsed_url.hostname or '').lower()
+
+        trusted = hostname in trusted_sources
+
+        if allow_subdomains and not trusted:
+            trusted = any(hostname.endswith(f'.{source}') for source in trusted_sources)
+
+        if parsed_url.scheme != 'https' or not trusted or parsed_url.port not in (None, 443):
+            raise RuntimeWarning(f"This modpack is potentially malicious! URL escapes trusted sources: '{url}'")
+
+        return url
+
+
+    # Download one file and verify its provider-supplied hash
+    def get_mod_url(mod_data):
+        file_path = os.path.join(mod_data['destination'], mod_data['file_name'])
+
+        for url in mod_data['urls']:
+            try:
+                if not cs_download_url(url, mod_data['file_name'], mod_data['destination']):
+                    continue
+
+                file_hash = hashlib.new(mod_data['hash_type'])
+
+                with open(file_path, 'rb') as file:
+                    for chunk in iter(lambda: file.read(1048576), b''):
+                        file_hash.update(chunk)
+
+                if file_hash.hexdigest().lower() == mod_data['hash'].lower():
+                    return True
+
+                if os.path.isfile(file_path):
+                    os.remove(file_path)
+
+            except Exception:
+                if os.path.isfile(file_path):
+                    os.remove(file_path)
+
+                continue
+
+        send_log('download_modpack_files', f"failed to validate '{mod_data['file_name']}'", 'warning')
+        return False
+
+
+    metadata = []
+
+    mr_index = os.path.join(test_server, 'modrinth.index.json')
+    cf_manifest = os.path.join(test_server, 'manifest.json')
+    cf_modlist = os.path.join(test_server, 'modlist.html')
+
+
+    # Modrinth
+    if import_data.get('pack_type') == 'mrpack' and os.path.isfile(mr_index):
+        try:
+            with open(mr_index, 'r', encoding='utf-8', errors='ignore') as file:
+                modrinth_data = json.load(file)
+
+            for mod_data in modrinth_data['files']:
+
+                # Discard client-side only files
+                if mod_data.get('env', {}).get('server', None) != 'required':
+                    continue
+
+                for download_link in mod_data['downloads']:
+                    validate_url(download_link, ('cdn.modrinth.com',))
+
+                destination = validate_path(mod_data['path'])
+                metadata.append({
+                    'urls': mod_data['downloads'],
+                    'hash': mod_data['hashes']['sha512'],
+                    'hash_type': 'sha512',
+                    'file_name': os.path.basename(destination),
+                    'destination': os.path.dirname(destination)
+                })
+
+        except (KeyError, IndexError, TypeError, ValueError) as e:
+            send_log('download_modpack_files', f'failed to parse Modrinth pack files: {format_traceback(e)}', 'warning')
+            return False
+
+
+    # CurseForge client export
+    elif import_data.get('pack_type') == 'zip' and os.path.isfile(cf_manifest) and os.path.isfile(cf_modlist):
+        try:
+            with open(cf_manifest, 'r', encoding='utf-8', errors='ignore') as file:
+                curseforge_data = json.load(file)
+
+            if curseforge_data.get('manifestType') != 'minecraftModpack':
+                if progress_func:
+                    progress_func(100)
+                return True
+
+            manifest_files = {
+                str(mod_data['fileID']): mod_data
+                for mod_data in curseforge_data.get('files', [])
+                if mod_data.get('fileID')
+            }
+
+            cf_provider = addons.modpack_manager.get_provider('curseforge')
+            curseforge_files = cf_provider.get_files(manifest_files.keys())
+            hash_types = {1: 'sha1', 2: 'md5'}
+
+            for file_id, manifest_data in manifest_files.items():
+                required = manifest_data.get('required', True)
+                file_data = curseforge_files.get(file_id)
+
+                # Required file could not be resolved
+                if not file_data:
+                    if required:
+                        send_log('download_modpack_files', f"failed to resolve required CurseForge file '{file_id}'", 'warning')
+                        return False
+
+                    continue
+
+                # Make sure the API result belongs to the requested project/file
+                if str(file_data.get('id')) != file_id or str(file_data.get('modId')) != str(manifest_data.get('projectID')):
+                    if required:
+                        send_log('download_modpack_files', f"CurseForge file '{file_id}' failed identity validation", 'warning')
+                        return False
+
+                    continue
+
+                # Respect unavailable/third-party restricted files
+                download_url = file_data.get('downloadUrl')
+                available = file_data.get('isAvailable', True)
+                if not available or not download_url:
+                    if required:
+                        reason = 'marked unavailable' if not available else 'third-party download is restricted'
+                        send_log('download_modpack_files', f"required CurseForge file '{file_id}' ({file_data.get('fileName') or 'unknown'}) cannot be downloaded: {reason}", 'warning')
+                        return False
+
+                    continue
+
+                validate_url(download_url, ('forgecdn.net',), True)
+
+                # Only accept a plain API-provided file name
+                raw_name = str(file_data.get('fileName') or '').strip()
+                file_name = ntpath.basename(raw_name)
+
+                if not file_name or file_name in ('.', '..') or file_name != raw_name or ntpath.splitdrive(file_name)[0]:
+                    raise RuntimeWarning(f"This modpack is potentially malicious! use of an invalid CurseForge file name: '{raw_name}'")
+
+                # Prefer SHA-1, then MD5
+                hashes = {}
+                for hash_data in file_data.get('hashes') or []:
+                    hash_type = hash_types.get(hash_data.get('algo'))
+                    hash_value = hash_data.get('value')
+
+                    if hash_type and hash_value:
+                        hashes[hash_type] = hash_value
+
+                if hashes.get('sha1'):  hash_type = 'sha1'
+                elif hashes.get('md5'): hash_type = 'md5'
+                else:
+                    if required:
+                        send_log('download_modpack_files', f"required CurseForge file '{file_id}' has no supported hash", 'warning')
+                        return False
+
+                    continue
+
+                destination = validate_path(os.path.join('mods', file_name))
+                metadata.append({
+                    'urls': [download_url],
+                    'hash': hashes[hash_type],
+                    'hash_type': hash_type,
+                    'file_name': os.path.basename(destination),
+                    'destination': os.path.dirname(destination)
+                })
+
+
+            # Apply CurseForge overrides only after the user acknowledges installing a client pack
+            overrides = curseforge_data.get('overrides')
+            if overrides:
+                overrides_path = validate_path(overrides)
+
+                if os.path.isdir(overrides_path):
+                    for file_name in os.listdir(overrides_path):
+                        source = os.path.join(overrides_path, file_name)
+                        destination = validate_path(file_name)
+
+                        if os.path.isdir(source):
+                            copytree(source, destination, dirs_exist_ok=True)
+
+                        else:
+                            folder_check(os.path.dirname(destination))
+                            copy(source, destination)
+
+                    safe_delete(overrides_path)
+
+        except (KeyError, IndexError, TypeError, ValueError) as e:
+            send_log('download_modpack_files', f'failed to parse CurseForge pack files: {format_traceback(e)}', 'warning')
+            return False
+
+
+    # If nothing needs to be downloaded
+    if not metadata:
+        if progress_func:
+            progress_func(100)
+
+        return True
+
+
+    # Download and validate every referenced file
+    with ThreadPoolExecutor(max_workers=20) as pool:
+        for index, result in enumerate(pool.map(get_mod_url, metadata), 1):
+            if progress_func:
+                progress_func(round((index / len(metadata)) * 100))
+
+            if not result:
+                return False
+
+    return True
 
 
 # Moves paths.tmpsvr to actual server and checks for ACL and other file validity

--- a/source/core/server/foundry.py
+++ b/source/core/server/foundry.py
@@ -2552,6 +2552,8 @@ def scan_modpack(update=False, progress_func=None):
 
     extract_archive(file_path, test_server)
     move_files_root(test_server)
+    client_pack = False
+    client_pack_name = None
 
     if progress_func:
         progress_func(50)
@@ -2727,7 +2729,35 @@ def scan_modpack(update=False, progress_func=None):
             send_log('scan_modpack', f"determined modpack type 'Modrinth'", 'info')
 
 
-    # Approach #2: look for "ServerStarter"
+    # Approach #2: Look for CurseForge "manifest.json"
+    if file_path.endswith('.zip') and not pack_provider:
+        cf_manifest = os.path.join(test_server, 'manifest.json')
+        cf_modlist = os.path.join(test_server, 'modlist.html')
+
+        # "modlist.html" identifies the normal CurseForge client export layout
+        client_pack = os.path.isfile(cf_modlist)
+
+        if os.path.isfile(cf_manifest):
+            try:
+                with open(cf_manifest, 'r', encoding='utf-8', errors='ignore') as file:
+                    curseforge_data = json.load(file)
+
+                if curseforge_data.get('manifestType') == 'minecraftModpack':
+                    client_pack_name = curseforge_data.get('name')
+
+                    cf_provider = addons.modpack_manager.get_provider('curseforge')
+                    cf_metadata = cf_provider.get_import_metadata(curseforge_data)
+
+                    if cf_metadata:
+                        pack_provider = 'curseforge'
+                        pack_metadata = cf_metadata
+                        send_log('scan_modpack', "determined modpack provider 'CurseForge'", 'info')
+
+            except (OSError, TypeError, ValueError) as e:
+                send_log('scan_modpack', f"failed to parse CurseForge metadata: {format_traceback(e)}", 'warning')
+
+
+    # Approach #3: look for "ServerStarter"
     server_starter = False
     yaml_list = []
     for file in glob(os.path.join(test_server, '*.*')):
@@ -2818,7 +2848,7 @@ def scan_modpack(update=False, progress_func=None):
         send_log('scan_modpack', f"determined modpack type 'ServerStarter'", 'info')
 
 
-    # Approach #3: inspect "variables.txt"
+    # Approach #4: inspect "variables.txt"
     elif os.path.exists('variables.txt'):
         with open('variables.txt', 'r', encoding='utf-8', errors='ignore') as f:
             variables = {}
@@ -2834,7 +2864,7 @@ def scan_modpack(update=False, progress_func=None):
         send_log('scan_modpack', f"found 'variables.txt'", 'info')
 
 
-    # Approach #4: inspect "settings.cfg"
+    # Approach #5: inspect "settings.cfg"
     elif os.path.exists('settings.cfg'):
         with open('settings.cfg', 'r', encoding='utf-8', errors='ignore') as f:
 
@@ -2930,7 +2960,7 @@ def scan_modpack(update=False, progress_func=None):
                         break
 
 
-    # Approach #5: inspect server files
+    # Approach #6: inspect server files
     if not data['version'] or not data['type']:
         send_log('scan_modpack', f"no valid scripts or 'server.jar', using a manual file scan", 'info')
 
@@ -3031,6 +3061,11 @@ def scan_modpack(update=False, progress_func=None):
     os.chdir(cwd)
     if data['type'] and data['version'] and data['name']:
 
+        client_search = None
+        if client_pack and not update:
+            client_search = constants.format_search_query(client_pack_name or data['name'] or file_path)
+            send_log('scan_modpack', "detected client pack", 'debug')
+
         # If the server isn't being updated, make sure it creates a new server
         if data['name'] and not update:
             data['name'] = new_server_name(process_name(data['name']))
@@ -3047,6 +3082,8 @@ def scan_modpack(update=False, progress_func=None):
             'pack_metadata': pack_metadata,
             'pack_icon': pack_icon
         }
+
+        data['client_search'] = client_search
 
         if progress_func:
             progress_func(100)

--- a/source/core/server/foundry.py
+++ b/source/core/server/foundry.py
@@ -1751,16 +1751,8 @@ def pre_server_update(telepath=False, host=None):
     for jar in glob(os.path.join(paths.tmpsvr, '*.jar')):
         os.remove(jar)
 
-    # Remove stale Modrinth metadata before installing the replacement
-    if server_obj.is_modpack == 'mrpack':
-        index_name = 'modrinth.index.json' if os_name == 'windows' else '.modrinth.index.json'
-        index_path = os.path.join(paths.tmpsvr, index_name)
-
-        if os.path.isfile(index_path):
-            if os_name == 'windows':
-                run_proc(f'attrib -H "{index_path}"')
-
-            os.remove(index_path)
+    # Remove stale modpack metadata before installing the replacement
+    addons.modpack_manager.clear_metadata(paths.tmpsvr)
 
     safe_delete(os.path.join(paths.tmpsvr, 'addons'))
     safe_delete(os.path.join(paths.tmpsvr, 'disabled-addons'))
@@ -2537,6 +2529,11 @@ def scan_modpack(update=False, progress_func=None):
         file_path = import_data['path'] = addons.download_modpack(import_data['name'], url, download_progress)
 
 
+    # Pull out modpack web details if they exist
+    pack_provider = import_data.get('pack_provider')
+    pack_metadata = import_data.get('pack_metadata')
+
+
     # Test archive first
     if not os.path.isfile(file_path) or file_path.split('.')[-1] not in ['zip', 'mrpack']:
         return False
@@ -2624,7 +2621,7 @@ def scan_modpack(update=False, progress_func=None):
         mr_index = os.path.join(test_server, 'modrinth.index.json')
 
         if os.path.isfile(mr_index):
-            mr_version = addons.modpack_provider.get_file_version(file_path)
+            mr_version = addons.modpack_manager.get_provider('modrinth').get_file_version(file_path)
             with open(mr_index, 'r', encoding='utf-8', errors='ignore') as f:
                 modrinth_data = json.loads(f.read())
 
@@ -2724,6 +2721,7 @@ def scan_modpack(update=False, progress_func=None):
                 for result in pool.map(get_mod_url, metadata):
                     if not result: return result
 
+            pack_provider = 'modrinth'
             send_log('scan_modpack', f"determined modpack type 'Modrinth'", 'info')
 
 
@@ -3042,7 +3040,9 @@ def scan_modpack(update=False, progress_func=None):
             'version': data['version'],
             'build': data['build'],
             'launch_flags': data['launch_flags'],
-            'pack_type': data['pack_type']
+            'pack_type': data['pack_type'],
+            'pack_provider': pack_provider,
+            'pack_metadata': pack_metadata
         }
 
         if progress_func:
@@ -3094,6 +3094,18 @@ def finalize_modpack(update=False, progress_func=None, *args):
         send_log('finalize_modpack', log_content, 'info')
 
 
+        # Create modpack metadata files
+        pack_provider = import_data.get('pack_provider')
+        pack_metadata = import_data.get('pack_metadata')
+        metadata_names = addons.modpack_manager.get_metadata_names()
+
+        if pack_provider and pack_metadata:
+            provider = addons.modpack_manager.get_provider(pack_provider)
+
+            if provider:
+                provider.write_metadata(pack_metadata, test_server)
+
+
         # Finish migrating data to paths.tmpsvr
         for item in glob(os.path.join(test_server, '*')):
             file_name = os.path.basename(item)
@@ -3112,14 +3124,19 @@ def finalize_modpack(update=False, progress_func=None, *args):
                     copy(item, paths.tmpsvr)
                     continue
 
-                elif file_name == 'modrinth.index.json':
-                    index_name = 'modrinth.index.json' if os_name == 'windows' else '.modrinth.index.json'
+                elif file_name in metadata_names:
+                    index_name = file_name if os_name == 'windows' else f'.{file_name}'
                     index_path = os.path.join(paths.tmpsvr, index_name)
+
                     if os.path.isfile(index_path):
-                        if os_name == 'windows': run_proc(f'attrib -H "{index_path}"')
+                        if os_name == 'windows':
+                            run_proc(f'attrib -H "{index_path}"')
                         os.remove(index_path)
+
                     copy(item, index_path)
-                    if os_name == 'windows': run_proc(f'attrib +H "{index_path}"')
+                    if os_name == 'windows':
+                        run_proc(f'attrib +H "{index_path}"')
+
                     continue
 
                 elif file_name.endswith('.png'): continue
@@ -3137,7 +3154,7 @@ def finalize_modpack(update=False, progress_func=None, *args):
             for item in glob(os.path.join(new_path, '*')):
                 file_name = os.path.basename(item)
                 if os.path.isdir(item) or (os.path.isfile(item) and (file_name.endswith('.txt') or file_name.endswith('.yml') or file_name.endswith('.json') or file_name in valid_files)):
-                    if file_name == 'modrinth.index.json':
+                    if file_name in metadata_names:
                         continue
 
                     elif os.path.isdir(item) and file_name in ['mods', 'config', 'versions', 'libraries', 'resources', '.fabric']:

--- a/source/core/server/foundry.py
+++ b/source/core/server/foundry.py
@@ -5,6 +5,7 @@ from shutil import copytree, copy, move
 from configparser import NoOptionError
 from bs4 import BeautifulSoup
 from copy import deepcopy
+from io import BytesIO
 from glob import glob
 from PIL import Image
 import subprocess
@@ -2532,6 +2533,7 @@ def scan_modpack(update=False, progress_func=None):
     # Pull out modpack web details if they exist
     pack_provider = import_data.get('pack_provider')
     pack_metadata = import_data.get('pack_metadata')
+    pack_icon = import_data.get('pack_icon')
 
 
     # Test archive first
@@ -3042,7 +3044,8 @@ def scan_modpack(update=False, progress_func=None):
             'launch_flags': data['launch_flags'],
             'pack_type': data['pack_type'],
             'pack_provider': pack_provider,
-            'pack_metadata': pack_metadata
+            'pack_metadata': pack_metadata,
+            'pack_icon': pack_icon
         }
 
         if progress_func:
@@ -3167,6 +3170,24 @@ def finalize_modpack(update=False, progress_func=None, *args):
                         new_file = os.path.join(paths.tmpsvr, file_name)
                         if os.path.isfile(new_file) and file_name in valid_files: os.remove(new_file)
                         copy(item, paths.tmpsvr)
+
+
+        # Fall back to the modpack project icon if no server icon exists
+        server_icon = os.path.join(paths.tmpsvr, 'server-icon.png')
+        pack_icon = import_data.get('pack_icon')
+
+        if pack_icon and not os.path.isfile(server_icon):
+            try:
+                response = requests.get(pack_icon, timeout=10)
+                response.raise_for_status()
+
+                with Image.open(BytesIO(response.content)) as image:
+                    image = image.convert('RGBA')
+                    image = image.resize((64, 64), Image.Resampling.LANCZOS)
+                    image.save(server_icon, 'PNG')
+
+            except Exception as e:
+                send_log('finalize_modpack', f"failed to download modpack icon: {format_traceback(e)}", 'warning')
 
 
         # Create auto-mcs.ini

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -2864,7 +2864,8 @@ class ServerManager():
                     "needsUpdate":    False,
                     "updateString":   None,
                     "updateUrl":      None,
-                    "updateMetadata": None
+                    "updateMetadata": None,
+                    "updateIcon":     None
                 }
             }
 
@@ -2893,7 +2894,8 @@ class ServerManager():
                             "needsUpdate":    True,
                             "updateString":   getattr(update, 'display_version', None) or update.addon_version,
                             "updateUrl":      update.download_url,
-                            "updateMetadata": getattr(update, 'metadata', None)
+                            "updateMetadata": getattr(update, 'metadata', None),
+                            "updateIcon":     getattr(update, 'icon_url', None),
                         })
 
 

--- a/source/core/server/manager.py
+++ b/source/core/server/manager.py
@@ -99,7 +99,7 @@ class ServerObject():
         self.version:            str            = ""
         self.build:              str            = None
         self.custom_flags:       str            = ""
-        self.is_modpack:         str            = ""
+        self.is_modpack:         str | bool     = False
         self.proxy_enabled:      bool           = False
         self.geyser_enabled:     bool           = False
         self.auto_update:        str            = "false"
@@ -225,8 +225,8 @@ class ServerObject():
 
     # Reloads server information from static files
     def reload_config(self, reload_objects=False, _logging=True, _from_init=False):
+        from source.core.server.addons import AddonManager, modpack_manager
         from source.core.server.amscript import ScriptManager
-        from source.core.server.addons import AddonManager
         from source.core.server.foundry import latestMC
 
         if _from_init: reload_objects = True; _logging = False
@@ -272,11 +272,25 @@ class ServerObject():
         except:
             self.custom_flags = ''
 
+        # Resolve modpack state/provider
         try:
-            if self.config_file.get("general", "isModpack"):
-                modpack = self.config_file.get("general", "isModpack").lower()
-                if modpack: self.is_modpack = 'zip' if modpack != 'mrpack' else 'mrpack'
-        except: self.is_modpack = ''
+            raw_modpack = self.config_file.get("general", "isModpack", fallback="false").strip().lower()
+            is_modpack = bool(raw_modpack and raw_modpack != 'false')
+            if is_modpack: self.is_modpack = modpack_manager.resolve_server(self.name)
+            else: self.is_modpack = False
+
+        except:
+            raw_modpack = 'false'
+            is_modpack = False
+            self.is_modpack = False
+
+        # Normalize old config files
+        normalized = str(is_modpack).lower()
+        if raw_modpack != normalized:
+            try:
+                self.config_file.set('general', 'isModpack', normalized)
+                server_config(self.name, self.config_file)
+            except: pass
 
         try:
             if self.config_file.get("general", "enableProxy"):
@@ -285,8 +299,7 @@ class ServerObject():
 
         try:
             if self.config_file.get("general", "enableGeyser"):
-                supported = (constants.version_check(self.version, ">=", "1.13.2")
-                             and self.type.lower() in ['spigot', 'paper', 'purpur', 'fabric', 'quilt', 'neoforge'])
+                supported = (constants.version_check(self.version, ">=", "1.13.2") and self.type.lower() in ['spigot', 'paper', 'purpur', 'fabric', 'quilt', 'neoforge'])
                 enabled = self.config_file.get("general", "enableGeyser").lower() == 'true'
                 self.geyser_enabled = (supported and enabled)
         except: self.geyser_enabled = False
@@ -296,7 +309,7 @@ class ServerObject():
         self.update_string = ''
         if constants.app_online:
             if self.is_modpack and self.name in self._manager.update_list:
-                if self._manager.update_list[self.name]['updateString'] and self.is_modpack == 'mrpack':
+                if self.is_modpack != 'unknown' and self._manager.update_list[self.name]['updateString']:
                     self.update_string = self._manager.update_list[self.name]['updateString']
             else:
                 self.update_string = str(latestMC[self.type]) if version_check(latestMC[self.type], '>', self.version) else ''
@@ -304,8 +317,8 @@ class ServerObject():
                     self.update_string = ('b-' + str(latestMC['builds'][self.type])) if (tuple(map(int, (str(latestMC['builds'][self.type]).split(".")))) > tuple(map(int, (str(self.build).split("."))))) else ""
 
 
-            # Ensure automatic updates are disabled for non-mrpack modpacks
-            if self.is_modpack and self.is_modpack != 'mrpack': self.auto_update = 'false'
+            # Ensure automatic updates are disabled for unknown packs
+            if self.is_modpack == 'unknown': self.auto_update = 'false'
             else: self.auto_update = str(self.config_file.get("general", "updateAuto").lower())
 
             if self.update_string: self._view_notif('settings', viewed='')
@@ -2175,6 +2188,7 @@ class ServerObject():
 # Low calorie version of ServerObject for a ViewClass in the Server Manager screen
 class ViewObject():
     def __init__(self, _manager: 'ServerManager', server_name: str):
+        from source.core.server.addons import modpack_manager
         from source.core.server.foundry import latestMC
 
         self._manager = _manager
@@ -2207,19 +2221,18 @@ class ViewObject():
         except:
             pass
         try:
-            if self.config_file.get("general", "isModpack"):
-                modpack = self.config_file.get("general", "isModpack").lower()
-                if modpack:
-                    self.is_modpack = 'zip' if modpack != 'mrpack' else 'mrpack'
-        except:
-            self.is_modpack = ''
+            raw_modpack = self.config_file.get("general", "isModpack", fallback="false").strip().lower()
+            is_modpack = bool(raw_modpack and raw_modpack != 'false')
+            if is_modpack: self.is_modpack = modpack_manager.resolve_server(self.name)
+            else: self.is_modpack = False
+        except: self.is_modpack = False
 
 
         # Check update properties for UI stuff
         self.update_string = ''
         if constants.app_online:
             if self.is_modpack and self.name in self._manager.update_list:
-                if self._manager.update_list[self.name]['updateString'] and self.is_modpack == 'mrpack':
+                if self.is_modpack != 'unknown' and self._manager.update_list[self.name]['updateString']:
                     self.update_string = self._manager.update_list[self.name]['updateString']
             else:
                 self.update_string = str(latestMC[self.type]) if version_check(latestMC[self.type], '>', self.version) else ''
@@ -2845,12 +2858,13 @@ class ServerManager():
         def _process_server(path: str, *a):
             name = os.path.basename(path)
 
-            server_data = {
+            server_data: dict[str, dict] = {
                 name: {
-                    "updateAuto":   False,
-                    "needsUpdate":  False,
-                    "updateString": None,
-                    "updateUrl":    None
+                    "updateAuto":     False,
+                    "needsUpdate":    False,
+                    "updateString":   None,
+                    "updateUrl":      None,
+                    "updateMetadata": None
                 }
             }
 
@@ -2865,17 +2879,22 @@ class ServerManager():
                 try: serverBuild = str(config.get("general", "serverBuild"))
                 except NoOptionError: serverBuild = ""
 
-                try: isModpack = str(config.get("general", "isModpack"))
-                except NoOptionError: isModpack = ""
+                try:
+                    raw_modpack = str(config.get("general", "isModpack")).strip().lower()
+                    isModpack = bool(raw_modpack and raw_modpack != 'false')
+                except NoOptionError:
+                    isModpack = False
 
                 # Check if modpack needs an update if detected (show only if auto-updates are enabled)
                 if isModpack:
-                    if isModpack == 'mrpack':
-                        update = check_modpack_updates(name)
-                        if update:
-                            server_data[name]["needsUpdate"] = True
-                            server_data[name]["updateString"] = update.addon_version
-                            server_data[name]["updateUrl"] = update.download_url
+                    update = check_modpack_updates(name)
+                    if update:
+                        server_data[name].update({
+                            "needsUpdate":    True,
+                            "updateString":   getattr(update, 'display_version', None) or update.addon_version,
+                            "updateUrl":      update.download_url,
+                            "updateMetadata": getattr(update, 'metadata', None)
+                        })
 
 
                 # Check if normal server needs an update (show only if auto-updates are enabled)
@@ -3599,10 +3618,10 @@ def create_server_config(properties: dict, temp_server=False, modpack=False):
         try:    config.set('general', 'customFlags', ' '.join(properties['launch_flags']))
         except: pass
 
-        # Ensure non-mrpack modpacks aren't updated automatically
+        # Ensure unmanaged modpacks aren't updated automatically
+        config.set('general', 'isModpack', str(bool(modpack)).lower())
         if modpack:
-            config.set('general', 'isModpack', str(modpack))
-            value = 'prompt' if str(modpack) == 'mrpack' else 'false'
+            value = 'prompt' if properties.get('pack_provider') else 'false'
             config.set('general', 'updateAuto', value)
 
         else: config.set('general', 'updateAuto', 'prompt')

--- a/source/core/telepath.py
+++ b/source/core/telepath.py
@@ -1308,7 +1308,7 @@ def create_remote_obj(obj: object, request=True):
     global app
 
     # Restrict methods from being remotely accessible
-    endpoint_blacklist = ['set_directory', '_run_providers']
+    endpoint_blacklist = ['set_directory', '_run_providers', 'provider_registry']
 
     # Replace methods
     def __getattr__(self, name):

--- a/source/core/telepath.py
+++ b/source/core/telepath.py
@@ -2177,6 +2177,7 @@ def initialize_endpoints():
     create_endpoint(foundry.scan_import, 'create', True)
     create_endpoint(foundry.finalize_import, 'create', True)
     create_endpoint(foundry.scan_modpack, 'create', True)
+    create_endpoint(foundry.download_modpack_files, 'create', True)
     create_endpoint(foundry.finalize_modpack, 'create', True)
 
     create_endpoint(manager.clone_server, 'create', True, send_host=True)

--- a/source/ui/desktop/utility.py
+++ b/source/ui/desktop/utility.py
@@ -1186,11 +1186,14 @@ def open_server(server_name, wait_page_load=False, show_banner='', ignore_update
         while not server_obj.addon:
             time.sleep(0.05)
 
-        if server_obj.is_modpack == 'mrpack':
-            if constants.server_manager.update_list[server_obj.name]['updateUrl']:
+        if server_obj.is_modpack and server_obj.is_modpack != 'unknown':
+            update_data = constants.server_manager.update_list.get(server_obj.name)
+            if update_data and update_data.get('updateUrl'):
                 foundry.import_data = {
                     'name': server_obj.name,
-                    'url': constants.server_manager.update_list[server_obj.name]['updateUrl']
+                    'url': update_data['updateUrl'],
+                    'pack_provider': server_obj.is_modpack,
+                    'pack_metadata': update_data.get('updateMetadata')
                 }
                 os.chdir(constants.get_cwd())
                 constants.safe_delete(paths.temp)
@@ -1287,11 +1290,14 @@ def open_remote_server(instance, server_name, wait_page_load=False, show_banner=
             while not server_obj.addon:
                 time.sleep(0.05)
 
-            if server_obj.is_modpack == 'mrpack':
-                if update_list[server_obj.name]['updateUrl']:
+            if server_obj.is_modpack and server_obj.is_modpack != 'unknown':
+                update_data = update_list.get(server_obj.name)
+                if update_data and update_data.get('updateUrl'):
                     foundry.import_data = {
                         'name': server_obj.name,
-                        'url': update_list[server_obj.name]['updateUrl']
+                        'url': update_data['updateUrl'],
+                        'pack_provider': server_obj.is_modpack,
+                        'pack_metadata': update_data.get('updateMetadata')
                     }
                     os.chdir(constants.get_cwd())
                     constants.safe_delete(paths.temp)

--- a/source/ui/desktop/utility.py
+++ b/source/ui/desktop/utility.py
@@ -1193,7 +1193,8 @@ def open_server(server_name, wait_page_load=False, show_banner='', ignore_update
                     'name': server_obj.name,
                     'url': update_data['updateUrl'],
                     'pack_provider': server_obj.is_modpack,
-                    'pack_metadata': update_data.get('updateMetadata')
+                    'pack_metadata': update_data.get('updateMetadata'),
+                    'pack_icon': update_data.get('updateIcon')
                 }
                 os.chdir(constants.get_cwd())
                 constants.safe_delete(paths.temp)
@@ -1297,7 +1298,8 @@ def open_remote_server(instance, server_name, wait_page_load=False, show_banner=
                         'name': server_obj.name,
                         'url': update_data['updateUrl'],
                         'pack_provider': server_obj.is_modpack,
-                        'pack_metadata': update_data.get('updateMetadata')
+                        'pack_metadata': update_data.get('updateMetadata'),
+                        'pack_icon': update_data.get('updateIcon')
                     }
                     os.chdir(constants.get_cwd())
                     constants.safe_delete(paths.temp)

--- a/source/ui/desktop/views/server/import.py
+++ b/source/ui/desktop/views/server/import.py
@@ -356,7 +356,7 @@ class ServerImportModpackProgressScreen(ProgressScreen):
 
             def open_server_search(*args):
                 search_screen = utility.screen_manager.get_screen('ServerImportModpackSearchScreen')
-                search_screen.queue_discover_search(client_search)
+                search_screen.queue_discover_search(client_search, True)
                 utility.screen_manager.current = 'ServerImportModpackSearchScreen'
 
             Clock.schedule_once(open_server_search, 0)

--- a/source/ui/desktop/views/server/import.py
+++ b/source/ui/desktop/views/server/import.py
@@ -314,6 +314,54 @@ class ServerImportModpackProgressScreen(ProgressScreen):
             if final < 0: final = original
             self.progress_bar.update_progress(final)
 
+        # Interactive show-stopper for client-sided packs
+        def validate_modpack(*args):
+            result = foundry.scan_modpack(False, functools.partial(adjust_percentage, 20))
+
+            if not result:
+                return result
+
+            client_search = result.get('client_search') if isinstance(result, dict) else None
+            if not client_search:
+                return True
+
+            # Pause the ProgressScreen while the UI waits for a response
+            response = Event()
+            use_server_pack = {'value': False}
+
+            def continue_client_pack(*args):
+                response.set()
+
+            def find_server_pack(*args):
+                use_server_pack['value'] = True
+                response.set()
+
+            def show_client_prompt(*args):
+                self.show_popup(
+                    'query',
+                    'Client Modpack Detected',
+                    "This appears to be a CurseForge client modpack.\n\nWould you like to search for a server pack instead?",
+                    (continue_client_pack, find_server_pack)
+                )
+
+            Clock.schedule_once(show_client_prompt, 0)
+            response.wait()
+
+            # "No" means continue the current installation normally
+            if not use_server_pack['value']:
+                return True
+
+            # Stop this progress screen without showing its default error
+            self.cancel_progress()
+
+            def open_server_search(*args):
+                search_screen = utility.screen_manager.get_screen('ServerImportModpackSearchScreen')
+                search_screen.queue_discover_search(client_search)
+                utility.screen_manager.current = 'ServerImportModpackSearchScreen'
+
+            Clock.schedule_once(open_server_search, 0)
+            return True
+
         self.page_contents = {
 
             # Page name
@@ -345,7 +393,7 @@ class ServerImportModpackProgressScreen(ProgressScreen):
 
             # Server import requires all Java builds because it generally has to run the server to find the version
             (java_text, functools.partial(constants.java_check, functools.partial(adjust_percentage, 30)), 0),
-            ('Validating modpack', functools.partial(foundry.scan_modpack, False, functools.partial(adjust_percentage, 20)), 0),
+            ('Validating modpack', validate_modpack, 0),
             ("Downloading 'server.jar'", functools.partial(foundry.download_jar, functools.partial(adjust_percentage, 15), True), 0),
             ('Installing modpack', functools.partial(foundry.install_server, None, True), 15),
             ('Validating configuration', functools.partial(foundry.finalize_modpack, False, functools.partial(adjust_percentage, 10)), 0),
@@ -472,7 +520,7 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
 
         self.add_widget(float_layout)
 
-        Clock.schedule_once(functools.partial(self.search_bar.execute_search, ""), 0)
+        Clock.schedule_once(functools.partial(self.load_discover_search, ""), 0)
 
 
 # </editor-fold> ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/source/ui/desktop/views/server/import.py
+++ b/source/ui/desktop/views/server/import.py
@@ -316,7 +316,7 @@ class ServerImportModpackProgressScreen(ProgressScreen):
 
         # Interactive show-stopper for client-sided packs
         def validate_modpack(*args):
-            result = foundry.scan_modpack(False, functools.partial(adjust_percentage, 20))
+            result = foundry.scan_modpack(False, functools.partial(adjust_percentage, 10))
 
             if not result:
                 return result
@@ -340,7 +340,7 @@ class ServerImportModpackProgressScreen(ProgressScreen):
                 self.show_popup(
                     'query',
                     'Client Modpack Detected',
-                    "This appears to be a CurseForge client modpack.\n\nWould you like to search for a server pack instead?",
+                    "This modpack appears to be client-sided, and may be incompatible as a server.\n\nWould you like to search for a server pack instead?",
                     (continue_client_pack, find_server_pack)
                 )
 
@@ -394,6 +394,7 @@ class ServerImportModpackProgressScreen(ProgressScreen):
             # Server import requires all Java builds because it generally has to run the server to find the version
             (java_text, functools.partial(constants.java_check, functools.partial(adjust_percentage, 30)), 0),
             ('Validating modpack', validate_modpack, 0),
+            ('Downloading modpack files', functools.partial(foundry.download_modpack_files, False, functools.partial(adjust_percentage, 10)), 0),
             ("Downloading 'server.jar'", functools.partial(foundry.download_jar, functools.partial(adjust_percentage, 15), True), 0),
             ('Installing modpack', functools.partial(foundry.install_server, None, True), 15),
             ('Validating configuration', functools.partial(foundry.finalize_modpack, False, functools.partial(adjust_percentage, 10)), 0),

--- a/source/ui/desktop/views/server/import.py
+++ b/source/ui/desktop/views/server/import.py
@@ -405,7 +405,8 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
             'name': release.name,
             'url': release.download_url,
             'pack_provider': release.provider,
-            'pack_metadata': getattr(release, 'metadata', None)
+            'pack_metadata': getattr(release, 'metadata', None),
+            'pack_icon': getattr(release, 'icon_url', None)
         }
 
         def progress(*args):

--- a/source/ui/desktop/views/server/import.py
+++ b/source/ui/desktop/views/server/import.py
@@ -370,6 +370,40 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
             'click_function': functools.partial(self.select_discover_item, modpack)
         }
 
+    def get_discover_banners(self, modpack, release):
+        if not release:
+            return []
+
+        versions = list(getattr(release, 'versions', None) or [])
+        loaders = list(getattr(release, 'loaders', None) or [])
+        loader_names = {
+            'forge': 'Forge',
+            'neoforge': 'NeoForge',
+            'fabric': 'Fabric',
+            'quilt': 'Quilt'
+        }
+
+        loader_text = ' / '.join(
+            loader_names.get(str(loader).lower(), str(loader).title())
+            for loader in loaders
+        )
+
+        version_text = (
+            'Unknown' if not versions
+            else str(versions[0]) if len(versions) == 1
+            else f'{versions[0]}-{versions[-1]}'
+        )
+
+        text = f'{loader_text} {version_text}'.strip()
+
+        return [{
+            '__translate__': False,
+            'size': (200, 32),
+            'color': (0.4, 0.682, 1, 1),
+            'text': text,
+            'icon': 'information-circle.png'
+        }]
+
     def load_discover_item(self, modpack):
         detailed = modpack
 
@@ -379,6 +413,7 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
         releases = addons.get_modpack_versions(detailed) or []
         versions = self.build_discover_versions(releases)
         selected = self.get_discover_selected(versions)
+        release = self.get_discover_release(versions, selected)
 
         return {
             'item': detailed,
@@ -388,6 +423,7 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
             'icon_url': getattr(detailed, 'icon_url', None),
             'fallback_icon': 'extension-puzzle.png',
             'project_url': getattr(detailed, 'url', None),
+            'banners': self.get_discover_banners(detailed, release),
             'versions': versions,
             'selected': selected,
             'installed': None,

--- a/source/ui/desktop/views/server/import.py
+++ b/source/ui/desktop/views/server/import.py
@@ -361,7 +361,6 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.provider = addons.ModrinthModpackProvider()
 
     def generate_list_button(self, modpack, index, fade_in, highlight):
         return {
@@ -375,9 +374,9 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
         detailed = modpack
 
         if not getattr(detailed, 'description', None):
-            detailed = self.provider.get_modpack_info(detailed) or modpack
+            detailed = addons.get_modpack_info(detailed) or modpack
 
-        releases = self.provider.get_modpack_versions(detailed) or []
+        releases = addons.get_modpack_versions(detailed) or []
         versions = self.build_discover_versions(releases)
         selected = self.get_discover_selected(versions)
 
@@ -404,7 +403,9 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
         # get_modpack_url() here or it will resolve the newest release again.
         foundry.import_data = {
             'name': release.name,
-            'url': release.download_url
+            'url': release.download_url,
+            'pack_provider': release.provider,
+            'pack_metadata': getattr(release, 'metadata', None)
         }
 
         def progress(*args):
@@ -417,7 +418,7 @@ class ServerImportModpackSearchScreen(ListDiscoverLayout, MenuBackground):
         self.generate_list(
             translate("Modpack Search"),
             "search for modpacks above",
-            self.provider.search_modpacks,
+            addons.search_modpacks,
             empty_text = "there are no items to display"
         )
 

--- a/source/ui/desktop/views/server/manager/components.py
+++ b/source/ui/desktop/views/server/manager/components.py
@@ -753,8 +753,8 @@ class ServerButton(HoverButton):
                     {'name': 'Settings', 'icon': os.path.join('sm', 'advanced.png'), 'action': settings}
                 ]
             else:
-                if self.properties.is_modpack == 'zip': u = None
-                else:                                   u = self.properties.update_string
+                if self.properties.is_modpack == 'unknown': u = None
+                else: u = self.properties.update_string
                 self.context_options = [
                     {'name': 'Launch', 'icon': 'start-server.png', 'action': launch} if utility.screen_manager.current_screen.name != "ServerViewScreen" else None,
                     {'name': f'Update {"build" if u.startswith("b-") else f"{u}"}', 'icon': 'arrow-up.png', 'action': update} if u else None,

--- a/source/ui/desktop/views/server/manager/console.py
+++ b/source/ui/desktop/views/server/manager/console.py
@@ -28,7 +28,7 @@ def prompt_new_server(server_obj, *args):
         def wait_timer(*a):
             while utility.screen_manager.current_screen.popup_widget:
                 time.sleep(0.1)
-            if not constants.server_manager.current_server.is_modpack or constants.server_manager.current_server.is_modpack == 'mrpack':
+            if constants.server_manager.current_server.is_modpack != 'unknown':
                 Clock.schedule_once(prompt_updates, 0)
 
         dTimer(0, wait_timer).start()

--- a/source/ui/desktop/views/server/manager/settings.py
+++ b/source/ui/desktop/views/server/manager/settings.py
@@ -753,7 +753,8 @@ class ServerSettingsScreen(MenuBackground):
                         'name': server_obj.name,
                         'url': update_data['updateUrl'],
                         'pack_provider': server_obj.is_modpack,
-                        'pack_metadata': update_data.get('updateMetadata')
+                        'pack_metadata': update_data.get('updateMetadata'),
+                        'pack_icon': update_data.get('updateIcon')
                     }
 
                     os.chdir(constants.get_cwd())

--- a/source/ui/desktop/views/server/manager/settings.py
+++ b/source/ui/desktop/views/server/manager/settings.py
@@ -1489,7 +1489,8 @@ class UpdateModpackProgressScreen(ProgressScreen):
 
             # Modpack update requires all Java builds because it generally has to run the server to find the version
             (java_text, functools.partial(constants.java_check, functools.partial(adjust_percentage, 30)), 0),
-            ('Validating modpack', functools.partial(foundry.scan_modpack, True, functools.partial(adjust_percentage, 20)), 0),
+            ('Validating modpack', functools.partial(foundry.scan_modpack, True, functools.partial(adjust_percentage, 10)), 0),
+            ('Downloading modpack files', functools.partial(foundry.download_modpack_files, True, functools.partial(adjust_percentage, 10)), 0),
             ("Downloading 'server.jar'", functools.partial(foundry.download_jar, functools.partial(adjust_percentage, 10), True), 0),
             ('Installing modpack', functools.partial(foundry.install_server, None, True), 15),
             ('Creating pre-install back-up', server_obj.backup.save, 10),

--- a/source/ui/desktop/views/server/manager/settings.py
+++ b/source/ui/desktop/views/server/manager/settings.py
@@ -727,7 +727,7 @@ class ServerSettingsScreen(MenuBackground):
                 ), 0
             )
 
-        disabled = server_obj.is_modpack and server_obj.is_modpack != 'mrpack'
+        disabled = server_obj.is_modpack == 'unknown'
         sub_layout = ScrollItem()
         sub_layout.add_widget(BlankInput(pos_hint={"center_x": 0.5, "center_y": 0.5}, hint_text='automatic updates', disabled=disabled))
         sub_layout.add_widget(SwitchButton('auto-update', (0.5, 0.5), custom_func=toggle_auto_update, default_state=server_obj.auto_update == 'true', disabled=disabled))
@@ -737,23 +737,32 @@ class ServerSettingsScreen(MenuBackground):
 
         # Updates server
         def update_server(*a):
-            if server_obj.is_modpack == 'mrpack':
-                update_url = ''
+
+            # Provider-managed modpack
+            if server_obj.is_modpack and server_obj.is_modpack != 'unknown':
+                update_data = None
+
                 if server_obj._telepath_data:
-                    try:
-                        update_url = constants.server_manager.get_telepath_update(server_obj._telepath_data, server_obj.name)['updateUrl']
+                    try: update_data = constants.server_manager.get_telepath_update(server_obj._telepath_data, server_obj.name)
                     except KeyError: pass
 
-                else:
-                    update_url = constants.server_manager.update_list[server_obj.name]['updateUrl']
+                else: update_data = constants.server_manager.update_list.get(server_obj.name)
 
-                if update_url:
-                    foundry.import_data = {'name': server_obj.name, 'url': update_url}
+                if update_data and update_data.get('updateUrl'):
+                    foundry.import_data = {
+                        'name': server_obj.name,
+                        'url': update_data['updateUrl'],
+                        'pack_provider': server_obj.is_modpack,
+                        'pack_metadata': update_data.get('updateMetadata')
+                    }
+
                     os.chdir(constants.get_cwd())
                     constants.safe_delete(paths.temp)
                     utility.screen_manager.current = 'UpdateModpackProgressScreen'
 
-            else:
+
+            # Normal non-modpack server
+            elif not server_obj.is_modpack:
                 foundry.new_server_init()
                 foundry.new_server_info['type'] = server_obj.type
                 foundry.new_server_info['version'] = foundry.latestMC[server_obj.type]
@@ -785,7 +794,7 @@ class ServerSettingsScreen(MenuBackground):
         else:
             needs_update = constants.server_manager.update_list[server_obj.name]['needsUpdate']
 
-        if server_obj.is_modpack == 'zip':
+        if server_obj.is_modpack == 'unknown':
             def select_file(*a):
                 zip_file = file_popup("file", start_dir=paths.user_downloads, ext=["*.zip", "*.mrpack"], select_multiple=True, title='Select a modpack update')
 

--- a/source/ui/desktop/views/templates.py
+++ b/source/ui/desktop/views/templates.py
@@ -782,13 +782,24 @@ class ProgressScreen(MenuBackground):
     def allow_close(self, allow: bool):
         if self.telepath:
             banner = f'$Telepath$ action {"finished" if allow else "started"}: {self.page_contents["title"]}'
-            constants.api_manager.request(
+            response = constants.api_manager.request(
                 endpoint = '/main/allow_close',
                 host = self.telepath['host'],
                 port = self.telepath['port'],
                 args = {'allow': allow, 'banner': banner}
             )
-        else: constants.allow_close(allow)
+
+            if response is not True:
+                action = 'unlock' if allow else 'lock'
+                send_log(self.__class__.__name__, f"failed to {action} GUI window on Telepath host '{self.telepath['host']}:{self.telepath['port']}'", 'warning')
+
+            return response is True
+
+        return constants.allow_close(allow)
+
+    def cancel_progress(self):
+        self.error = True
+        self.allow_close(True)
 
     def open_server(self, *args, **kwargs):
         if self.telepath: open_remote_server(self.telepath, *args, **kwargs)

--- a/source/ui/desktop/views/templates.py
+++ b/source/ui/desktop/views/templates.py
@@ -861,6 +861,11 @@ class ProgressScreen(MenuBackground):
             # If it failed, execute default error
             if not test: return self.execute_error(self.page_contents['default_error'], exception=exception, log_data=(crash_log, file_path) if crash_log else None)
 
+            # Don't let a fast step outrun its UI transition
+            if self._step_animation_done:
+                self._step_animation_done.wait()
+                self._step_animation_done = None
+
             completed = x + 1 == len(self.page_contents['function_list'])
             if completed: audio.player.play('interaction/click_*', after=0.42, jitter=(0, 0.15))
             else:         audio.player.play('interaction/step', after=0.42, jitter=0.1, pitch=0.7, volume=0.75)
@@ -959,6 +964,7 @@ class ProgressScreen(MenuBackground):
         self.error = False
         self.start = False
         self.last_progress = 0
+        self._step_animation_done = None
 
         self.page_contents = None
 
@@ -1000,6 +1006,9 @@ class ProgressScreen(MenuBackground):
                 Animation.stop_all(self.steps.label_2)
                 self.steps.label_2.opacity = 1
 
+            animation_done = Event()
+            self._step_animation_done = animation_done
+
             def delayed_func(*args):
                 if num != 0:
                     # Label 1
@@ -1035,7 +1044,11 @@ class ProgressScreen(MenuBackground):
                 except IndexError: self.steps.label_4.text = ""
                 self.steps.label_4.y = self.steps.label_4.original_y
 
-            Clock.schedule_once(delayed_func, anim_duration+0.2 if self.start else 0)
+            def finalize_steps(*args):
+                try:     delayed_func(*args)
+                finally: animation_done.set()
+
+            Clock.schedule_once(finalize_steps, anim_duration + 0.2 if self.start else 0)
             self.start = True
 
 

--- a/source/ui/desktop/widgets/base.py
+++ b/source/ui/desktop/widgets/base.py
@@ -34,6 +34,7 @@ from kivy.properties import BooleanProperty, ObjectProperty, ListProperty
 
 from source.ui.desktop.utility import *
 from source.ui.desktop import utility
+from threading import Event
 
 
 

--- a/source/ui/desktop/widgets/layouts.py
+++ b/source/ui/desktop/widgets/layouts.py
@@ -458,6 +458,7 @@ class ListDiscoverLayout(ListSearchLayout):
     @staticmethod
     def _discover_version(item, index=0):
         return str(
+            getattr(item, 'display_version', None) or
             getattr(item, 'addon_version', None) or
             getattr(item, 'download_version', None) or
             getattr(item, 'version', None) or

--- a/source/ui/desktop/widgets/layouts.py
+++ b/source/ui/desktop/widgets/layouts.py
@@ -445,6 +445,8 @@ class ListDiscoverLayout(ListSearchLayout):
 
         self.detail_panel = None
         self.selected_item = None
+        self.pending_search = None
+        self.pending_select_first = False
         self.detail_request = 0
 
 
@@ -464,6 +466,26 @@ class ListDiscoverLayout(ListSearchLayout):
             getattr(item, 'version', None) or
             f'release {index + 1}'
         ).strip()
+
+    # Queues a search to be executed the next time this Discovery screen loads
+    def queue_discover_search(self, query, select_first=None):
+        if select_first is None: select_first = self.is_discover_wide()
+        self.pending_search = str(query or '').strip()
+        self.pending_select_first = bool(select_first)
+
+    # Executes the queued search, or a fallback query when loaded normally
+    def load_discover_search(self, default='', *args):
+        if self.pending_search is not None:
+            query = self.pending_search
+            self.pending_search = None
+
+        else:
+            query = default
+            self.pending_select_first = False
+
+        if self.search_bar:
+            self.search_bar.search_input.text = query
+            self.search_bar.execute_search(query)
 
     def find_discover_match(self, item, item_list):
         def normalize(value):
@@ -856,6 +878,10 @@ class ListDiscoverLayout(ListSearchLayout):
 
         response = super().gen_search_results(results, new_search, fade_in, highlight, animate_scroll, last_scroll, *args)
 
+        # Consume queued selection state for this search
+        select_first = self.pending_select_first
+        self.pending_select_first = False
+
         if isinstance(results, bool):
             return response
 
@@ -867,6 +893,10 @@ class ListDiscoverLayout(ListSearchLayout):
 
         self.sync_discover_visibility()
         Clock.schedule_once(self.resize_list, 0)
+
+        # Automatically open the first result when requested
+        if select_first and self.last_results:
+            Clock.schedule_once(functools.partial(self.select_discover_item, self.last_results[0]), 0)
 
         return response
 

--- a/source/ui/desktop/widgets/menus.py
+++ b/source/ui/desktop/widgets/menus.py
@@ -517,8 +517,13 @@ class DropActionBar(RelativeLayout):
         return version[1:] if version.startswith('v') else version
 
     @staticmethod
-    def _release_version(release, fallback=None):
-        return str(getattr(release, 'addon_version', None) or getattr(release, 'version', None) or fallback or '').strip()
+    def _release_version(release, fallback=None, display=False):
+        return str(
+            (getattr(release, 'display_version', None) if display else None) or
+            getattr(release, 'addon_version', None) or
+            getattr(release, 'version', None) or
+            fallback or ''
+        ).strip()
 
     def resize_bar(self, *args):
         self.dropdown.pos = (0, 0)
@@ -539,7 +544,7 @@ class DropActionBar(RelativeLayout):
 
         self.selected = selected
 
-        if selected: self.dropdown.change_text(self._release_version(self.option_map[selected], selected), False)
+        if selected: self.dropdown.change_text(self._release_version(self.option_map[selected], selected, display=True), False)
         else:        self.dropdown.change_text('unavailable', False)
 
         self.dropdown.button.disabled = not bool(labels)
@@ -552,7 +557,7 @@ class DropActionBar(RelativeLayout):
         self.selected = option
         release = self.option_map[option]
 
-        self.dropdown.change_text(self._release_version(release, option), False)
+        self.dropdown.change_text(self._release_version(release, option, display=True), False)
         self.refresh_action()
 
         if self.select_func:


### PR DESCRIPTION
This PR adds CurseForge as a first-class provider for add-ons and modpacks, while restructuring the existing Modrinth implementation around shared multi-provider modpack discovery/update workflow.

### Changes
* Add CurseForge support for mods, plugins, and modpacks through the CurseForge API
* Refactor add-on and modpack handling around provider-based routing with concurrent cross-provider search
* Add responsive Discovery detail panels with release selection, provider metadata, project icons, and reusable queued searches
* Preserve exact provider/release identity for managed modpacks using provider-specific metadata sidecars
* Normalize `isModpack` configuration to a boolean while resolving `modrinth`, `curseforge`, and unmanaged `unknown` state at runtime
* Add CurseForge server-pack discovery with dedicated-server-only filtering, release metadata, update detection, and exact server-pack downloads
* Preserve backwards compatibility for existing Modrinth and unmanaged modpack installations
* Add CurseForge client-export detection and offer automatic Discovery lookup for an available server pack
* Allow client exports to continue as custom/unpublished packs by resolving their manifest dependencies when permitted
* Enforce provider download permissions, safe extraction paths, trusted download sources, and provider-supplied hashes
* Defer referenced Modrinth and CurseForge file downloads until after modpack validation through a shared download stage
* Apply CurseForge overrides and derive Minecraft/loader metadata directly from client manifests
* Carry provider metadata and project icons through install, update, automatic-update, and Telepath workflows
* Prevent unmanaged or ambiguously identified modpacks from receiving automatic provider updates
* Fix archive root detection and clear stale modpack extraction state between imports
* Add Telepath support for the new modpack download workflow and bump the Telepath protocol to `1.3.1`
* Improve `ProgressScreen` synchronization so fast operations cannot outrun their Kivy UI transitions
* Improve close-lock acknowledgement/logging for progress operations