### PR TITLE
Fix for #174

### DIFF
--- a/source/core/constants.py
+++ b/source/core/constants.py
@@ -886,7 +886,7 @@ def get_public_ip() -> str:
 public_ip: str = ""
 
 # Global Cloudscraper object for global app use
-def return_scraper(url_path: str, head=False, params=None) -> requests.Response:
+def return_scraper(url_path: str, head=False, params=None, timeout=(10, 30)) -> requests.Response:
     global global_scraper
 
     if not global_scraper:
@@ -894,17 +894,18 @@ def return_scraper(url_path: str, head=False, params=None) -> requests.Response:
             browser = {'custom': f'{app_title}/{app_version}', 'platform': os_name, 'mobile': False},
         )
 
-    return global_scraper.head(url_path) if head else global_scraper.get(url_path, params=params)
+    return global_scraper.head(url_path, timeout=timeout) if head else global_scraper.get(url_path, params=params, timeout=timeout)
 global_scraper: cloudscraper.CloudScraper = None
 
 
 # Return HTML content or status code (using Cloudscraper)
-def get_url(url: str, return_code=False, only_head=False, return_response=False, params=None) -> requests.Response:
+def get_url(url: str, return_code=False, only_head=False, return_response=False, params=None, timeout=(10, 30)) -> requests.Response:
     global global_scraper
+
     max_retries = 10
     for retry in range(0, max_retries + 1):
         try:
-            html = return_scraper(url, head=(return_code or only_head), params=params)
+            html = return_scraper(url, head=(return_code or only_head), params=params, timeout=timeout)
             send_log('get_url', f"request to '{url}': {html.status_code}")
             return html.status_code if return_code \
                 else html if (only_head or return_response) \
@@ -926,13 +927,14 @@ def get_url(url: str, return_code=False, only_head=False, return_response=False,
 
 
 # Download a file with Cloudscraper and return data if the downloaded file exists
-def cs_download_url(url: str, file_name: str, destination_path: str) -> bool:
+def cs_download_url(url: str, file_name: str, destination_path: str, timeout=(10, 60)) -> bool:
     global global_scraper
     max_retries = 10
+
     send_log('cs_download_url', f"requesting from '{url}' to download '{file_name}' to '{destination_path}'...")
     for retry in range(0, max_retries + 1):
         try:
-            web_file = return_scraper(url)
+            web_file = return_scraper(url, timeout=timeout)
             full_path = os.path.join(destination_path, file_name)
             folder_check(destination_path)
             with open(full_path, 'wb') as file:
@@ -954,31 +956,44 @@ def cs_download_url(url: str, file_name: str, destination_path: str) -> bool:
 
 
 # Download file from URL to directory (not using Cloudscraper)
-def download_url(url: str, file_name: str, output_path: str, progress_func=None) -> str or None:
+def download_url(url: str, file_name: str, output_path: str, progress_func=None, timeout=(10, 60)) -> str or None:
     send_log('download_url', f"requesting from '{url}' to download '{file_name}' to '{output_path}'...")
     headers = {'User-Agent': 'Mozilla/5.0'}
-    response = requests.get(url, headers=headers, stream=True)
-    try: response.raise_for_status()
-    except Exception as e:
-        send_log('download_url', f"request to '{url}' error: {format_traceback(e)}", 'error')
-        raise e
 
     file_path = os.path.join(output_path, file_name)
     folder_check(output_path)
 
-    with open(file_path, 'wb') as file:
-        total_length = response.headers.get('content-length')
-        if total_length is None:  # no content length header
-            file.write(response.content)
-            if progress_func:
-                progress_func(1, 1, 1)
-        else:
-            total_length = int(total_length)
-            chunk_size = 8192
-            for chunk, data in enumerate(response.iter_content(chunk_size=chunk_size), 0):
-                file.write(data)
-                if progress_func:
-                    progress_func(chunk, chunk_size, total_length)
+    try:
+        with requests.get(url, headers=headers, stream=True, timeout=timeout) as response:
+            response.raise_for_status()
+
+            with open(file_path, 'wb') as file:
+                total_length = response.headers.get('content-length')
+
+                if total_length is None:
+                    file.write(response.content)
+                    if progress_func:
+                        progress_func(1, 1, 1)
+
+                else:
+                    total_length = int(total_length)
+                    chunk_size = 8192
+
+                    for chunk, data in enumerate(response.iter_content(chunk_size=chunk_size), 0):
+                        if not data: continue
+                        file.write(data)
+
+                        if progress_func:
+                            progress_func(chunk, chunk_size, total_length)
+
+    except Exception as e:
+        try:
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+        except: pass
+
+        send_log('download_url', f"request to '{url}' error: {format_traceback(e)}", 'error')
+        raise
 
     if os.path.isfile(file_path):
         send_log('download_url', f"download of '{file_name}' complete: '{file_path}'")
@@ -1168,9 +1183,13 @@ def get_repo_scripts() -> list:
     global ams_web_list
 
     try:
-        latest_commit = requests.get("https://api.github.com/repos/macarooni-man/auto-mcs/commits").json()[0]['sha']
-        repo_data = requests.get(
-            f"https://api.github.com/repos/macarooni-man/auto-mcs/git/trees/{latest_commit}?recursive=1").json()
+        response = requests.get("https://api.github.com/repos/macarooni-man/auto-mcs/commits", timeout=(5, 15))
+        response.raise_for_status()
+        latest_commit = response.json()[0]['sha']
+
+        response = requests.get(f"https://api.github.com/repos/macarooni-man/auto-mcs/git/trees/{latest_commit}?recursive=1", timeout=(5, 15))
+        response.raise_for_status()
+        repo_data = response.json()
 
         script_dict = {}
         ams_list = []
@@ -1416,7 +1435,9 @@ def check_app_updates() -> bool:
 
                 # Retrieve & parse metadata file separately
                 if name.startswith('commit-metadata'):
-                    data, checksum = requests.get(url).text.split("Checksums (MD5):")
+                    response = requests.get(url, timeout=(5, 20))
+                    response.raise_for_status()
+                    data, checksum = response.text.split("Checksums (MD5):")
                     dev_update_data['desc'] = re.sub(r':\s+', ':     ', data.strip())
 
                     # Parse metadata at the top
@@ -3189,20 +3210,39 @@ class SearchManager():
         }
 
     # Cache the guides to a .json file
-    def cache_pages(self):
+    def cache_pages(self, cancel_func=None):
         if not app_online:
             self._send_log(f"failed to fully initialize SearchManager: {app_title} is offline", 'error')
             return False
 
-        def get_html_contents(url: str):
-            while True:
-                req = requests.get(url)
-                if req.status_code == 200:
-                    break
-                else:
-                    time.sleep(3)
+        def cancelled():
+            return bool(cancel_func and cancel_func())
 
-            return BeautifulSoup(req.content, features='html.parser')
+        def wait_delay(delay):
+            end = time.monotonic() + delay
+            while time.monotonic() < end:
+                if cancelled(): return False
+                time.sleep(min(0.1, end - time.monotonic()))
+            return True
+
+        def get_html_contents(url: str):
+            for attempt in range(3):
+                if cancelled(): return None
+
+                try:
+                    req = requests.get(url, timeout=(5, 15))
+                    if req.status_code == 200:
+                        return BeautifulSoup(req.content, features='html.parser')
+
+                    self._send_log(f"guide request to '{url}' returned {req.status_code}", 'warning')
+
+                except requests.RequestException as e:
+                    self._send_log(f"guide request to '{url}' failed: {format_traceback(e)}", 'warning')
+
+                if attempt < 2 and not wait_delay(1):
+                    return None
+
+            return None
 
         cache_file = os.path.join(paths.cache, 'guide-cache.json')
         cache_data = {}
@@ -3217,14 +3257,18 @@ class SearchManager():
         # If not, scrape the website
         base_url = "https://www.auto-mcs.com/guides"
         content = get_html_contents(base_url)
+        if content is None:
+            return False
 
         for a in content.find_all('a', class_="portfolio-hover-item"):
+            if cancelled(): return False
 
             sub_url = base_url + a.get('href').replace('guides/', '')
             title = a.get_text().strip()
 
             guide = get_html_contents(sub_url)
-            time.sleep(1)
+            if guide is None: continue
+            if not wait_delay(1): return False
 
             # Clean-up guide by removing unnecessary elements
             for tag in guide("div", id='toc'):
@@ -3248,8 +3292,10 @@ class SearchManager():
                             href = f'https://auto-mcs.com{href}'
 
                         if href.endswith('.png') or href.endswith('.jpg'):
-                            new_href = requests.get(href, allow_redirects=True).history[-1].headers['location']
-                            time.sleep(1)
+                            response = requests.get(href, allow_redirects=True, timeout=(5, 15))
+                            response.raise_for_status()
+                            new_href = response.url
+                            if not wait_delay(1): return False
                             tag.replace_with(BeautifulSoup(f'<img src="{new_href}">', 'html.parser').img)
                             continue
 

--- a/source/core/logger.py
+++ b/source/core/logger.py
@@ -100,92 +100,106 @@ def create_boot_log(object_data: str):
     formatted_properties = "\n".join(data_list)
     send_log(object_data, f'initializing {app_title} with the following properties:\n{formatted_properties}', 'info', 'ui')
 
-# Generates a crash or error report
-def create_error_log(exception, error_info=None):
+# Retrieve recent application logging without waiting on the logger worker
+def recent_log_snapshot(limit=150) -> str:
+    log_lines = []
+
+    # Include anything already flushed to the current application log
+    try:
+        log_path = log_manager._get_file_name()
+        if os.path.isfile(log_path):
+            with open(log_path, 'r', encoding='utf-8', errors='ignore') as f:
+                log_lines.extend(list(deque(f, maxlen=limit)))
+    except: pass
+
+    # Include anything still buffered in memory
+    acquired = False
+    try:
+        acquired = log_manager._db_lock.acquire(timeout=0.25)
+
+        if acquired:
+            entries = list(log_manager._log_db)
+            log_lines.extend(log_manager._format_buffer(entries))
+
+    except: pass
+
+    finally:
+        if acquired: log_manager._db_lock.release()
+
+    return ''.join(log_lines[-limit:]).strip()
+
+# Generates and saves a formatted AME report
+def _create_ame_report(exception_code: str, traceback_data: str, crash_type='fatal', log_data='', log_title='Logging since last interaction', extra_info=None):
     from source.core.tools import playit
 
-    # No error info can be provided with a hard crash
-    if error_info:
-        crash_type = 'error'
-        error_info = f'''
-        Error information:
-
-            {error_info}
-
-'''
-    else:
-        crash_type = 'fatal'
-        error_info = ''
-
-    # Remove file paths from exception
-    trimmed_exception = []
-    exception_lines = exception.splitlines()
-    last_line = None
-
-    for line in exception_lines:
-        if ("192.168" in line or "auto-mcs-gui" in line) and 'File "' in line:
-            indent, line_end = line.split('File "', 1)
-            path, line_end = line_end.split('"', 1)
-            line = f'{indent}File "{os.path.basename(path.strip())}"{line_end.strip()}'
-
-        elif "site-packages" in line.lower() and 'File "' in line:
-            indent, line_end = line.split('File "', 1)
-            path, line_end = line_end.split('"', 1)
-            line = f'{indent}File "site-packages{path.split("site-packages", 1)[1]}"{line_end.strip()}'
-
-        if ", line" in line:
-            last_line = line
-
-        trimmed_exception.append(line)
-
-    exception_summary = trimmed_exception[-1].strip() + f'\n    ({last_line.strip()})'
-    exception_code    = trimmed_exception[-1].strip() + f' ({last_line.split(",", 1)[0].strip()} - {last_line.split(",")[-1].strip()})'
-    trimmed_exception = "\n".join(trimmed_exception)
-    # print(exception_code)
-
-
-    # Create AME code
-    # Generate code with last application path and last widget interaction
     path = constants.footer_path
     interaction = constants.last_widget
-    ame = (hashlib.shake_128(path.split("@")[0].strip().encode()).hexdigest(1) if path else "00") + "-" + hashlib.shake_128(exception_code.encode()).hexdigest(3)
+    server_manager = getattr(constants, 'server_manager', None)
+    api_manager = getattr(constants, 'api_manager', None)
 
+    # Generate AME code from application path and exception signature
+    ame = (
+        hashlib.shake_128(path.split("@")[0].strip().encode()).hexdigest(1) if path else "00"
+    ) + "-" + hashlib.shake_128(exception_code.encode()).hexdigest(3)
 
-    # Check for 'Logs' folder in application directory
-    # If it doesn't exist, create a new folder called 'Logs'
+    # Crash report location
     folder = 'errors' if crash_type == 'error' else 'crashes'
     log_dir = os.path.join(paths.logs, folder)
     constants.folder_check(log_dir)
 
-
     # Timestamp
     time_stamp = dt.now().strftime(constants.fmt_date("%#H-%M-%S_%#m-%#d-%y"))
     time_formatted = dt.now().strftime(constants.fmt_date("%#I:%M:%S %p  %#m/%#d/%Y"))
-
 
     # Header
     header = f'Auto-MCS Exception:    {ame}  '
     splash = generate_splash(True)
 
     header_len = 42
-    calculated_space = 0
     splash_line = ("||" + (' ' * (round((header_len * 1.5) - (len(splash) / 2)) - 2)) + splash)
 
-
-    # Last interaction
-    last_interaction = '\n'.join(i.strip() for i in log_manager.since_last_interaction())
-
-    try:    is_telepath = bool(constants.server_manager.current_server._telepath_data)
+    # Runtime state
+    try:    is_telepath = bool(server_manager and server_manager.current_server and server_manager.current_server._telepath_data)
     except: is_telepath = False
 
+    try:    running_servers = server_manager.running_servers if server_manager else {}
+    except: running_servers = {}
 
-    # Format running servers
+    try:    proxy_active = bool(playit.manager and playit.manager._tunnels_in_use())
+    except: proxy_active = False
+
+    try:    api_active = bool(api_manager and api_manager.running)
+    except: api_active = False
+
     def format_servers():
         return ', '.join([
             f"{i}: {server.type} {server.version}"
-            for i, server in enumerate(constants.server_manager.running_servers.values(), 1)
+            for i, server in enumerate(running_servers.values(), 1)
         ])
 
+    # Keep general info aligned with optional report-specific information
+    info_rows = [
+        ('Severity', crash_type.title()),
+        *(extra_info or []),
+
+        ('Version', format_version()),
+        ('Online', constants.app_online),
+        ('Permissions', "Admin-level" if is_admin() else "User-level"),
+        ('UI Language', get_locale_string(True)),
+        ('Headless', "True" if constants.headless else "False"),
+        ('Active servers', format_servers() if running_servers else "None"),
+        ('Proxy (playit)', "Active" if proxy_active else "Inactive"),
+        ('Telepath client', "Active" if is_telepath else "Inactive"),
+        ('Telepath server', "Active" if api_active else "Inactive"),
+
+        ('Processor info', format_cpu()),
+        ('Used memory', format_ram()),
+    ]
+
+    general_info = '\n'.join([
+        f'        {f"{label}:":<18} {value}'
+        for label, value in info_rows
+    ])
 
     log = f"""{'=' * (header_len * 3)}
 {"||" + (' ' * round((header_len * 1.5) - (len(header) / 2) - 1)) + header + (' ' * round((header_len * 1.5) - (len(header)) + 14)) + "||"}
@@ -195,20 +209,7 @@ def create_error_log(exception, error_info=None):
 
     General Info:
 
-        Severity:          {crash_type.title()}
-
-        Version:           {format_version()}
-        Online:            {constants.app_online}
-        Permissions:       {"Admin-level" if is_admin() else "User-level"}
-        UI Language:       {get_locale_string(True)}
-        Headless:          {"True" if constants.headless else "False"}
-        Active servers:    {format_servers() if constants.server_manager.running_servers else "None"}
-        Proxy (playit):    {"Active" if playit.manager and playit.manager._tunnels_in_use() else "Inactive"}
-        Telepath client:   {"Active" if is_telepath else "Inactive"}
-        Telepath server:   {"Active" if constants.api_manager.running else "Inactive"}
-
-        Processor info:    {format_cpu()}
-        Used memory:       {format_ram()}
+{general_info}
 
 
 
@@ -231,21 +232,19 @@ def create_error_log(exception, error_info=None):
 
 
     AME traceback:
-        {'' if not error_info else error_info}
-        Exception Summary:
-    {textwrap.indent(exception_summary, "        ")}
 
-{textwrap.indent(trimmed_exception, "        ")}
+{textwrap.indent(traceback_data.strip(), "        ")}
 
 
-    Logging since last interaction:
+    {log_title}:
 
-{textwrap.indent(last_interaction, "        ")}"""
+{textwrap.indent(log_data.strip(), "        ")}"""
 
-    # Only write to disk if the app is compiled and logging is enabled
+    # Only write to disk if logging is enabled
     if enable_logging:
         file_name = os.path.abspath(os.path.join(log_dir, f"ame-{crash_type}_{time_stamp}.log"))
-        with open(file_name, "w") as log_file:
+
+        with open(file_name, 'w', encoding='utf-8') as log_file:
             log_file.write(log)
 
         # Remove old logs
@@ -254,8 +253,8 @@ def create_error_log(exception, error_info=None):
             file_data[file] = os.stat(file).st_mtime
 
         sorted_files = sorted(file_data.items(), key=itemgetter(1))
-
         delete = len(sorted_files) - max_log_count
+
         for x in range(0, delete):
             os.remove(sorted_files[x][0])
 
@@ -263,6 +262,99 @@ def create_error_log(exception, error_info=None):
         file_name = None
 
     return ame, file_name
+
+# Generates a fatal AME report for a forced hang termination
+def create_hang_log(thread_dump: str, reason: str):
+
+    # Snapshot queue state without depending on the logger worker
+    try:    logger_queue = log_manager._q.qsize()
+    except: logger_queue = 'Unknown'
+
+    recent_logs = recent_log_snapshot()
+    if not recent_logs:
+        recent_logs = 'No recent application logging available'
+
+    exception_code = f'ThreadHangError: {reason}'
+    traceback_data = f"""Exception Summary:
+
+    (ThreadHangError) {reason}
+
+Active thread dump:
+
+{textwrap.indent(thread_dump.strip(), "    ")}"""
+
+    return _create_ame_report(
+        exception_code,
+        traceback_data,
+        'fatal',
+        recent_logs,
+        'Recent application logging',
+        [
+            ('Failure type', 'Thread hang'),
+            ('Active threads', threading.active_count()),
+            ('Logger queue', logger_queue),
+        ]
+    )
+
+# Generates a crash or error report
+def create_error_log(exception, error_info=None):
+
+    # No error info can be provided with a hard crash
+    crash_type = 'error' if error_info else 'fatal'
+
+    # Remove file paths from exception
+    trimmed_exception = []
+    exception_lines = exception.splitlines()
+    last_line = None
+
+    for line in exception_lines:
+        if ("192.168" in line or "auto-mcs-gui" in line) and 'File "' in line:
+            indent, line_end = line.split('File "', 1)
+            path, line_end = line_end.split('"', 1)
+            line = f'{indent}File "{os.path.basename(path.strip())}"{line_end.strip()}'
+
+        elif "site-packages" in line.lower() and 'File "' in line:
+            indent, line_end = line.split('File "', 1)
+            path, line_end = line_end.split('"', 1)
+            line = f'{indent}File "site-packages{path.split("site-packages", 1)[1]}"{line_end.strip()}'
+
+        if ", line" in line:
+            last_line = line
+
+        trimmed_exception.append(line)
+
+    # Format exception summary/code
+    exception_name = trimmed_exception[-1].strip()
+
+    if last_line:
+        exception_summary = exception_name + f'\n    ({last_line.strip()})'
+        exception_code = exception_name + f' ({last_line.split(",", 1)[0].strip()} - {last_line.split(",")[-1].strip()})'
+    else:
+        exception_summary = exception_name
+        exception_code = exception_name
+
+    trimmed_exception = "\n".join(trimmed_exception)
+
+    # Add optional error context
+    error_data = ''
+
+    if error_info:
+        error_data = f"""Error information:
+
+    {error_info}
+
+"""
+
+    traceback_data = f"""{error_data}Exception Summary:
+
+    {exception_summary}
+
+{trimmed_exception}"""
+
+    try:    log_data = '\n'.join(i.strip() for i in log_manager.since_last_interaction())
+    except: log_data = 'No recent application logging available'
+
+    return _create_ame_report(exception_code, traceback_data, crash_type, log_data)
 
 # Kivy forwarder to AppLogger
 class KivyToLoggerHandler(logging.Handler):
@@ -376,20 +468,18 @@ class AppLogger():
         payload = (str(object_data), str(message), str(level), str(stack), _raw)
 
         # Enqueue line for background write
-        try:
-            # Prefer dropping general level data if the queue is full
-            if self._q.full() and level in ('debug', 'info'):
-                try: self._q.get_nowait(); self._q.task_done()
-                except queue.Empty: pass
-            self._q.put_nowait(payload)
-
+        try: self._q.put_nowait(payload)
         except queue.Full:
 
-            # For warnings/errors/fatal, block briefly to avoid loss
-            try: self._q.put(payload, timeout=0.25)
+            # Drop new low-priority messages instead of disturbing queued data/barriers
+            if level in ('debug', 'info'):
+                return
 
-            # Last resort: block until there is space so critical logs still go through the worker
-            except queue.Full: self._q.put(payload)
+            # Briefly wait for important messages, but never block indefinitely
+            try: self._q.put(payload, timeout=0.25)
+            except queue.Full:
+                try: sys.__stderr__.write(f"Logging queue full, dropped {level} message from {object_data}\n")
+                except: pass
 
     def _add_entry(self, object_data: str, message: str, level: str, stack: str):
         data = {'time': dt.now(), 'object_data': object_data, 'level': level, 'stack': stack, 'message': message}
@@ -407,10 +497,17 @@ class AppLogger():
 
         # Drain until stop is set and queue is empty
         while not self._stop.is_set() or not self._q.empty():
-            try: object_data, message, level, stack, _raw = self._q.get(timeout=0.2)
+            try: payload = self._q.get(timeout=0.2)
             except queue.Empty: continue
 
             try:
+                # Barrier used by flush()
+                if isinstance(payload, threading.Event):
+                    payload.set()
+                    continue
+
+                object_data, message, level, stack, _raw = payload
+
                 # Build the entry on the worker thread
                 data = self._add_entry(object_data, message, level, stack)
                 self._print(data, _raw)
@@ -524,26 +621,23 @@ class AppLogger():
         return out
 
     # Wait until all queued logs are written
-    def flush(self, timeout: float = None):
-        start = time.monotonic()
-        self._q.join()
-        if timeout is not None and (time.monotonic() - start) > timeout:
-            return False
-        return True
+    def flush(self, timeout: float = 5):
+        marker = threading.Event()
+        try: self._q.put(marker, timeout=0.25)
+        except queue.Full: return False
+        return marker.wait(timeout)
 
     # Stop the writer thread and flush
-    def close(self, graceful: bool = True):
-        if graceful:
-            self._stop.set()
-            self.flush()
-        else:
-            self._stop.set()
+    def close(self, graceful: bool = True, timeout=5):
+        flushed = self.flush(timeout) if graceful else True
+        self._stop.set()
+        return flushed
 
     # Flush the queue and write the entire in-memory log to a file, and clear the db
-    def dump_to_disk(self) -> str:
+    def dump_to_disk(self, timeout=5) -> str:
 
         # Ensure background thread has printed/added everything it has
-        self.flush()
+        self.flush(timeout)
         path = self._get_file_name()
 
         # Don’t write if logging is disabled or deque is empty, but still return the path for consistency
@@ -571,7 +665,7 @@ class AppLogger():
                 f.write(line)
 
         self._prune_logs()
-        constants.api_manager.logger.dump_to_disk()
+        constants.api_manager.logger.dump_to_disk(timeout)
         return path
 
     # Get everything since the last UI action
@@ -669,20 +763,14 @@ class AuditLogger():
         payload = (str(event), host, str(extra_data), str(server_name))
 
         # Enqueue line for background write
-        try:
-            # Prefer dropping general level data if the queue is full
-            if self._q.full():
-                try: self._q.get_nowait(); self._q.task_done()
-                except queue.Empty: pass
-            self._q.put_nowait(payload)
-
+        try: self._q.put_nowait(payload)
         except queue.Full:
 
-            # For warnings/errors/fatal, block briefly to avoid loss
+            # Briefly wait for audit events, but never block indefinitely
             try: self._q.put(payload, timeout=0.25)
-
-            # Last resort: block until there is space so critical logs still go through the worker
-            except queue.Full: self._q.put(payload)
+            except queue.Full:
+                try: sys.__stderr__.write(f"Audit logging queue full, dropped event '{event}'\n")
+                except: pass
 
     # Heavy work happens here on the worker thread; returns a fully formatted line or None to drop
     def _add_entry(self, event: str, host, extra_data: str, server_name: str):
@@ -743,6 +831,11 @@ class AuditLogger():
             except queue.Empty: continue
 
             try:
+                # Barrier used by flush()
+                if isinstance(payload, threading.Event):
+                    payload.set()
+                    continue
+
                 # Handle tuple payloads from _dispatch
                 if isinstance(payload, tuple) and len(payload) == 4:
                     event, host, extra_data, server_name = payload
@@ -774,26 +867,23 @@ class AuditLogger():
         return log_data
 
     # Wait until all queued audit lines are in 'self._audit_db'
-    def flush(self, timeout: float = None):
-        start = time.monotonic()
-        self._q.join()
-        if timeout is not None and (time.monotonic() - start) > timeout:
-            return False
-        return True
+    def flush(self, timeout: float = 5):
+        marker = threading.Event()
+        try: self._q.put(marker, timeout=0.25)
+        except queue.Full: return False
+        return marker.wait(timeout)
 
     # Stop the writer thread
-    def close(self, graceful: bool = True):
-        if graceful:
-            self._stop.set()
-            self.flush()
-        else:
-            self._stop.set()
+    def close(self, graceful: bool = True, timeout=5):
+        flushed = self.flush(timeout) if graceful else True
+        self._stop.set()
+        return flushed
 
     # Flush queue and write the entire in-memory audit buffer to disk and clear the buffer
-    def dump_to_disk(self) -> str:
+    def dump_to_disk(self, timeout=5) -> str:
 
         # Ensure background thread has appended everything to 'self._audit_db'
-        self.flush()
+        self.flush(timeout)
         path = self._get_file_name()
 
         # Don’t write if logging is disabled or deque is empty, but still return the path for consistency

--- a/source/core/server/addons.py
+++ b/source/core/server/addons.py
@@ -3803,7 +3803,9 @@ def geyser_addons(addon_manager, addon_id=None, update=False):
         if not addon_id or addon_id == 'geyser':
             api_url = 'https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest'
             url = f'{api_url}/downloads/spigot'
-            version = requests.get(api_url).json().get('version')
+            response = requests.get(api_url, timeout=(5, 15))
+            response.raise_for_status()
+            version = response.json().get('version')
             addon = AddonWebObject('Geyser', 'bukkit', 'GeyserMC', 'Bedrock packet compatibility layer', url, 'geyser', version)
             addon.download_url = url
             final_list.append(addon)
@@ -3812,7 +3814,9 @@ def geyser_addons(addon_manager, addon_id=None, update=False):
         if not addon_id or addon_id == 'floodgate':
             api_url = 'https://download.geysermc.org/v2/projects/floodgate/versions/latest/builds/latest'
             url = f'{api_url}/downloads/spigot'
-            version = requests.get(api_url).json().get('version')
+            response = requests.get(api_url, timeout=(5, 15))
+            response.raise_for_status()
+            version = response.json().get('version')
             addon = AddonWebObject('Floodgate', 'bukkit', 'GeyserMC', 'Bedrock account compatibility layer', url, 'floodgate', version)
             addon.download_url = url
             final_list.append(addon)

--- a/source/core/server/amscript.py
+++ b/source/core/server/amscript.py
@@ -65,7 +65,9 @@ class AmsWebObject():
         # Retrieve metadata
         for name, url in data.items():
             if name == 'meta':
-                meta = requests.get(url).content.decode()
+                response = requests.get(url, timeout=(5, 15))
+                response.raise_for_status()
+                meta = response.content.decode()
                 for line in meta.splitlines():
 
                     # Get title of script

--- a/source/core/server/foundry.py
+++ b/source/core/server/foundry.py
@@ -159,34 +159,55 @@ def apply_template(template: dict):
 
 # Grabs instant server template (.ist) files from GitHub repo
 ist_data = {}
-def get_repo_templates(force_download: bool = False):
+def get_repo_templates(force_download: bool = False, cancel_func=None):
     global ist_data
 
     if ist_data and not force_download:
         return
 
+    def cancelled():
+        return bool(cancel_func and cancel_func())
+
     if not os.path.exists(paths.templates) or force_download:
 
         try:
-            latest_commit = requests.get("https://api.github.com/repos/macarooni-man/auto-mcs/commits").json()[0]['sha']
-            repo_data = requests.get(f"https://api.github.com/repos/macarooni-man/auto-mcs/git/trees/{latest_commit}?recursive=1").json()
+            response = requests.get("https://api.github.com/repos/macarooni-man/auto-mcs/commits", timeout=(5, 15))
+            response.raise_for_status()
+            latest_commit = response.json()[0]['sha']
+
+            if cancelled(): return
+
+            response = requests.get(f"https://api.github.com/repos/macarooni-man/auto-mcs/git/trees/{latest_commit}?recursive=1", timeout=(5, 15))
+            response.raise_for_status()
+            repo_data = response.json()
 
             # Organize all script files
             folder_check(paths.templates)
+
             for file in repo_data['tree']:
+                if cancelled(): return
+
                 if file['path'].startswith('template-library'):
                     if "/" in file['path']:
                         file_name = file['path'].split("/")[1]
                         url = f'https://raw.githubusercontent.com/macarooni-man/auto-mcs/refs/heads/main/{quote(file["path"])}'
                         final_path = os.path.join(paths.templates, file_name)
+
                         if os.path.isfile(final_path): os.remove(final_path)
                         download_url(url, file_name, paths.templates)
-        except: ist_data = {}
 
+        except Exception as e:
+            ist_data = {}
+            send_log('get_repo_templates', f'failed to retrieve templates: {constants.format_traceback(e)}', 'error')
+
+    if cancelled(): return
 
     if os.path.exists(paths.templates):
         ist_data = {}
+
         for ist in glob(os.path.join(paths.templates, '*.yml')):
+            if cancelled(): return
+
             data = parse_template(ist)
             if ist not in ist_data:
                 ist_data[os.path.basename(ist)] = data
@@ -262,7 +283,7 @@ def find_latest_mc():
         elif name == "neoforge":
             # Neoforge
             url = "https://maven.neoforged.net/api/maven/versions/releases/net/neoforged/neoforge"
-            reqs = requests.get(url)
+            reqs = requests.get(url, timeout=timeout)
             for version in reversed(reqs.json()['versions']):
                 if all([s not in version for s in ['beta', 'alpha', 'snapshot']]):
                     v = version.split('.')
@@ -280,7 +301,7 @@ def find_latest_mc():
             latestMC["paper"] = version
 
             build_url = f"{url}/versions/{version}"
-            reqs = requests.get(build_url)
+            reqs = requests.get(build_url, timeout=timeout)
             jsonObject = reqs.json()
             latestMC["builds"]["paper"] = jsonObject['builds'][0]
 
@@ -294,7 +315,7 @@ def find_latest_mc():
             latestMC["purpur"] = version
 
             build_url = f"{url}/{version}"
-            reqs = requests.get(build_url)
+            reqs = requests.get(build_url, timeout=timeout)
             jsonObject = reqs.json()
             latestMC["builds"]["purpur"] = jsonObject['builds']['latest']
 
@@ -415,14 +436,11 @@ def get_data_versions() -> dict or None:
     # Request data and see if page exists
     url = f"https://minecraft.wiki/w/Data_version"
     data = None
-    try: data = requests.get(url, timeout=2)
-    except requests.exceptions.ReadTimeout:
-        page_exists = False
+    try: data = requests.get(url, timeout=5)
+    except requests.RequestException:
+        pass
 
-    if data.status_code != 200:
-        page_exists = False
-
-    if not data or not page_exists:
+    if not data or data.status_code != 200:
         status_code = getattr(data, 'status_code', None)
         send_log('get_data_versions', f'failed to retrieve data versions: {status_code} ({url})', 'error')
         return None

--- a/source/core/telepath.py
+++ b/source/core/telepath.py
@@ -712,15 +712,15 @@ class TelepathManager():
 
 
     # --------- Client-side functions to call the endpoints from a remote device -------- #
-    def login(self, ip: str, port: int, timeout=3):
+    def login(self, ip: str, port: int, timeout: int = 5):
 
         # Negotiate HTTPS first, and fall back to legacy HTTP
         if not self._negotiate_session(ip, port, timeout):
             return {}
 
         # Get the server's public key and create an encrypted token
-        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID)
-        except AttributeError as e:
+        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID, timeout)
+        except Exception as e:
             self._send_log(f"failed to get a public key from '{ip}:{port}': {constants.format_traceback(e)}", 'error')
             return {}
 
@@ -734,7 +734,7 @@ class TelepathManager():
 
         try:
             session = self._get_session(ip, port)
-            data = session.post(url, json=host_data, timeout=5).json()
+            data = session.post(url, json=host_data, timeout=timeout).json()
             if 'access-token' in data:
                 self.jwt_tokens[(ip, port)] = data['access-token']
                 return_data = deepcopy(data)
@@ -768,15 +768,16 @@ class TelepathManager():
 
         return False
 
-    def request_pair(self, ip: str, port: int):
+    def request_pair(self, ip: str, port: int, timeout: int = 5):
 
         # Negotiate HTTPS first, and fall back to legacy HTTP
-        if not self._negotiate_session(ip, port):
+        if not self._negotiate_session(ip, port, timeout):
             return None
 
         # Get the server's public key and create an encrypted token
-        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID)
-        except AttributeError:
+        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID, timeout)
+        except Exception as e:
+            self._send_log(f"failed to get a public key from '{ip}:{port}': {constants.format_traceback(e)}", 'error')
             return None
 
         url = self._get_url(ip, port, 'telepath/request_pair')
@@ -788,7 +789,7 @@ class TelepathManager():
         # Eventually add a retry algorithm
 
         try:
-            data = requests.post(url, json=host_data, timeout=5).json()
+            data = requests.post(url, json=host_data, timeout=timeout).json()
             return data
 
         except Exception as e:
@@ -796,11 +797,11 @@ class TelepathManager():
 
         return None
 
-    def submit_pair(self, ip: str, port: int, code: str):
+    def submit_pair(self, ip: str, port: int, code: str, timeout: int = 5):
 
         # Get the server's public key and create an encrypted token
-        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID)
-        except AttributeError as e:
+        try: token = self.auth.public_encrypt(self._get_url(ip, port, 'telepath/get_public_key'), UNIQUE_ID, timeout)
+        except Exception as e:
             self._send_log(f"failed to get a public key from '{ip}:{port}': {constants.format_traceback(e)}", 'error')
             return None
 
@@ -812,7 +813,7 @@ class TelepathManager():
 
         # Eventually add a retry algorithm
         try:
-            data = requests.post(url, json=host_data).json()
+            data = requests.post(url, json=host_data, timeout=timeout).json()
             if 'access-token' in data:
                 self.jwt_tokens[(ip, port)] = data['access-token']
                 return_data = deepcopy(data)
@@ -910,12 +911,15 @@ class AuthHandler():
 
 
     # Use this to retrieve a public key from the server, and encrypt & return the content
-    def public_encrypt(self, url: str, content: str or int) -> dict:
+    def public_encrypt(self, url: str, content: str or int, timeout: int = 5) -> dict:
         content = str(content)
 
         # Retrieve public key PEM and convert it back to a Python object
         # Requires a pre-constructed '/telepath/get_public_key' URL
-        pem = requests.get(url).json()
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        pem = response.json()
+
         public_key = serialization.load_pem_public_key(
             pem.encode('utf-8'),
             backend = default_backend()
@@ -1936,7 +1940,12 @@ class RemoteAmsWebObject(RemoteObject):
 def initialize_endpoints():
 
     # Wait until ServerManager is initialized
-    while not constants.server_manager: time.sleep(0.1)
+    deadline = time.monotonic() + 35
+    while not constants.server_manager:
+        if time.monotonic() >= deadline:
+            send_log('initialize_endpoints', 'failed to initialize Telepath endpoints: ServerManager timed out after 35 seconds', 'fatal')
+            return False
+        time.sleep(0.1)
 
 
     # API endpoints for authentication

--- a/source/core/tools/playit.py
+++ b/source/core/tools/playit.py
@@ -195,12 +195,12 @@ class PlayitManager():
         self._proto_key   = None   # Protocol registry key
         self._secret_key  = None   # For authentication to guest account
 
-
     @property
     def _download_url(self) -> str:
         if not self._exec_version:
             release_url = 'https://github.com/playit-cloud/playit-agent/releases/latest'
-            r = requests.get(release_url)
+            r = requests.get(release_url, timeout=(5, 15))
+            r.raise_for_status()
             self._exec_version = r.url.rsplit('/')[-1].strip('v')
         return f'{self._git_base}/download/v{self._exec_version}/{self._download_name}'
 
@@ -482,6 +482,7 @@ class PlayitManager():
 
     # ----- API tunnel handling -----
     def _request(self, endpoint: str, *args, **kwargs):
+        kwargs.setdefault('timeout', 15)
         return self.session.post(f"{self._api_base}/{endpoint.strip('/')}", *args, **kwargs).json()
 
     # Creates two lists of all tunnels, sorted by protocol

--- a/source/launcher.py
+++ b/source/launcher.py
@@ -1,4 +1,4 @@
-from traceback import format_exc
+from traceback import format_exc, format_stack
 from os import path
 import threading
 import argparse
@@ -397,6 +397,41 @@ def load_cache():
     from source.core.server import addons
     addons.load_addon_cache(telepath=True)
 
+# Dumps every active Python thread for diagnosing a stalled process
+def dump_thread_stacks() -> str:
+    frames = sys._current_frames()
+    output = []
+
+    for thread in threading.enumerate():
+        frame = frames.get(thread.ident)
+        if not frame: continue
+
+        output.append(
+            f"\n{'-' * 80}\n"
+            f"Thread: {thread.name} | ID: {thread.ident} | daemon: {thread.daemon}\n"
+            f"{'-' * 80}\n"
+            f"{''.join(format_stack(frame))}"
+        )
+
+    return ''.join(output)
+
+# Forcibly terminate a process that can no longer exit normally
+def terminate_hang(reason: str, exit_code=20):
+    from source.core import logger
+
+    thread_dump = dump_thread_stacks()
+    try:
+        ame, log_path = logger.create_hang_log(thread_dump, reason)
+        message = f"auto-mcs thread hang detected: {ame}\n"
+        if log_path: message += f"Full crash log available in: '{log_path}'\n"
+        sys.__stderr__.write(message)
+
+    except Exception as e:
+        try: sys.__stderr__.write(f"auto-mcs thread hang detected, but the crash report failed:\n{e}\n\n{thread_dump}\n")
+        except: pass
+
+    os._exit(exit_code)
+
 # Initialize Telepath if enabled
 def init_telepath():
     from source.core import constants, telepath
@@ -515,34 +550,48 @@ if __name__ == '__main__':
         playit.init_manager()
         constants.search_manager = constants.SearchManager()
 
-        # If app was just updated, re-install playit if it's installed
-        if was_updated: playit.manager.update_agent()
-
-        # Wait until ServerManager is initialized
-        while not constants.server_manager: time.sleep(0.1)
-
-        # Try to log into telepath servers automatically
-        if path.exists(paths.telepath_servers): constants.server_manager.check_telepath_servers()
-
         def background_launch(func, *a):
             global exit_app, crash
 
             if exit_app or crash:
-                return
+                return False
 
-            try: func()
+            try: func(*a)
             except Exception as e:
                 send_log('background.background_launch', f"error running background task '{func}': {constants.format_traceback(e)}", 'error')
+
+            return not (exit_app or crash)
+
+        # If app was just updated, re-install playit if it's installed
+        if was_updated and not (exit_app or crash):
+            playit.manager.update_agent()
+
+        # Wait until ServerManager is initialized
+        server_manager_deadline = time.monotonic() + 30
+        while not constants.server_manager:
+            if exit_app or crash: return
+            if time.monotonic() >= server_manager_deadline:
+                terminate_hang('ServerManager failed to initialize within 30 seconds', 20)
+            time.sleep(0.1)
+
+        # Try to log into telepath servers automatically
+        if path.exists(paths.telepath_servers):
+            if not background_launch(constants.server_manager.check_telepath_servers): return
 
         # Find latest game versions and update data cache
         def get_versions(*a):
             foundry.find_latest_mc()
+            if exit_app or crash: return
+
             constants.server_manager.check_for_updates()
-            foundry.get_repo_templates(was_updated)
-        background_launch(constants.get_public_ip)
-        background_launch(get_versions)
-        background_launch(foundry.check_data_cache)
-        background_launch(constants.search_manager.cache_pages)
+            if exit_app or crash: return
+
+            foundry.get_repo_templates(was_updated, lambda: exit_app or crash)
+
+        if not background_launch(constants.get_public_ip): return
+        if not background_launch(get_versions): return
+        if not background_launch(foundry.check_data_cache): return
+        if not background_launch(constants.search_manager.cache_pages, lambda: exit_app or crash): return
 
 
         # Update variables in the background
@@ -623,11 +672,16 @@ if __name__ == '__main__':
 
 
     # Launch & threading logic
+    hang_interval = 30
     background_thread = threading.Thread(name='background', target=background, daemon=True)
 
     background_thread.start()
     foreground()
-    background_thread.join()
+    background_thread.join(timeout=hang_interval)
+
+    # A stuck background task must never keep the application alive indefinitely
+    if background_thread.is_alive():
+        terminate_hang(f'background failed to exit within {hang_interval}s after shutdown', 20 if crash else 0)
 
     # Exit with return code if there's a crash
     if crash: sys.exit(20)


### PR DESCRIPTION
## Summary

Fixes #174 by hardening auto-mcs against background operations that can prevent the process from exiting after the UI has already closed

The original shutdown behavior waited indefinitely for the launcher background thread with `background_thread.join()`. Several operations reachable from that thread could also block indefinitely due to unbounded HTTP requests, retry loops, executor workers, or logger queue flushing.

This PR makes those operations finite, allows startup/background work to stop when the app is closing, and adds a final shutdown safeguard, so that a stuck background thread can no longer leave auto-mcs running invisibly forever.

## Changes

### Background/shutdown handling

- Added cancellation checks between background startup operations so work stops once the UI exits or crashes.
- Added a 30-second timeout while waiting for `ServerManager` to initialize.
- Added a timeout to Telepath endpoint initialization instead of waiting indefinitely for `ServerManager`.
- Replaced the final unbounded background-thread join with a 30-second timeout.
- If the background thread still fails to exit after that timeout:
  - captures all active Python thread stacks;
  - generates a normal AME-style fatal report under `Logs/crashes`;
  - includes recent application logging and runtime state;
  - does not show the crash UI when the user intentionally closed the application;
  - forcibly terminates the process so it cannot remain running in the background.

### Network operations

Added finite connect/read timeouts to network operations that could previously block indefinitely, including:

- shared `get_url()` / Cloudscraper requests;
- shared file downloads;
- latest Minecraft/server-version lookups;
- instant-template retrieval;
- guide/search cache generation;
- AMScript repository metadata;
- Geyser/Floodgate metadata;
- Telepath authentication, public-key retrieval, pairing and login;
- Playit release/API requests;
- development update metadata.

The guide scraper also no longer retries failed requests forever and can abort while the application is shutting down.

### Logging

Reworked application and Telepath audit logger flushing.

Previously, both loggers relied on `Queue.join()`, which could wait indefinitely while other threads continued adding work to the queue. The existing `timeout` argument also only checked elapsed time *after* `Queue.join()` returned, so it could not actually stop a hung flush.

Logging now uses a FIFO barrier event:

- everything queued before the barrier is processed;
- new logging cannot extend a flush indefinitely;
- flushes have a real timeout;
- saturated logger queues cannot block callers forever.

Application and audit logs continue to flush normally during shutdown.

### AME reporting

Refactored crash report generation so ordinary exceptions and forced thread-hang reports share the same AME formatting/writing logic.

Thread-hang reports include:

- the hang reason;
- active thread count;
- logger queue state;
- complete Python stack traces for every active thread;
- application path and last interaction;
- recent application logging.

This should make any remaining occurrence of #174 directly diagnosable instead of only presenting as an orphaned background process.

## Validation

Regression testing was performed against the affected functionality, including:

- normal startup and shutdown
- closing auto-mcs while a server is running
- application-log flushing during shutdown
- fatal AME/crash reporting
- Telepath pairing, login, reconnect, remote server actions, logout, and audit logging
- server creation from a template
- Paper server/JAR downloading
- add-on provider searches and downloads
- Geyser, Floodgate, and ViaVersion installation
- amscript repository loading
- guide/search cache loading
- Playit agent linking and tunnel creation

A forced shutdown hang was also tested on Windows by intentionally blocking the background thread.

The UI closed normally, cleanup completed, and after 30 seconds auto-mcs:

1. detected that the background thread had not exited;
2. generated an `ame-fatal_*.log`
3. correctly identified the intentionally blocked background thread and exact source line in the thread dump
4. included recent shutdown logging
5. terminated the remaining process with no user-facing crash window

In short, it prevents the original shutdown hang and useful diagnostics if another blocking path is ever encountered in the future